### PR TITLE
fix: handle EADDRINUSE by retrying web server listen

### DIFF
--- a/src/web/index.ts
+++ b/src/web/index.ts
@@ -106,6 +106,14 @@ export function createWebServer(config: WebServerConfig): WebServer {
 	return {
 		start(): void {
 			startWatcher();
+			server.on("error", (error: NodeJS.ErrnoException) => {
+				if (error.code === "EADDRINUSE") {
+					console.error(`[web] Port ${port} in use, retrying in 2s…`);
+					setTimeout(() => server.listen(port, host), 2000);
+				} else {
+					throw error;
+				}
+			});
 			server.listen(port, host, () => {
 				console.log(`[web] UI available at http://${host}:${port}`);
 			});


### PR DESCRIPTION
When restarting via pm2, the old process may not have released port 7750 yet. This adds an error handler that retries the listen after 2 seconds instead of crashing.