### PR TITLE
feat: archive incoming images by date

### DIFF
--- a/src/imessage.ts
+++ b/src/imessage.ts
@@ -19,6 +19,7 @@ import type { MessageSender } from "./send.js";
 import type { Settings } from "./settings.js";
 import type { ChatStore } from "./store.js";
 import {
+	createArchiveImagesTask,
 	createCallAgentTask,
 	createCheckReplyEnabledTask,
 	createCommandHandlerTask,
@@ -58,6 +59,7 @@ export function createIMessageBot(config: IMessageBotConfig) {
 	// before
 	pipeline.before(createLogIncomingTask(digestLogger));
 	pipeline.before(createDropSelfEchoTask(echoFilter));
+	pipeline.before(createArchiveImagesTask(store));
 	pipeline.before(createStoreIncomingTask(store));
 	pipeline.before(createCheckReplyEnabledTask(getSettings));
 	pipeline.before(createDownloadImagesTask());

--- a/src/store.ts
+++ b/src/store.ts
@@ -11,10 +11,11 @@
  * The file is never rewritten — only appended to.
  */
 
+import { createHash } from "node:crypto";
 import { existsSync, mkdirSync } from "node:fs";
-import { appendFile } from "node:fs/promises";
-import { join } from "node:path";
-import type { MessageType } from "./types.js";
+import { appendFile, copyFile, readFile, stat } from "node:fs/promises";
+import { extname, join, relative } from "node:path";
+import type { IncomingMessage, MessageType } from "./types.js";
 
 // ── Message ───────────────────────────────────────────────────────────────────
 
@@ -52,14 +53,60 @@ export function firstLinePreview(text: string | null): string {
 	return full.includes("\n") ? `${firstLine}...` : full;
 }
 
+function localDay(date: Date): string {
+	const year = date.getFullYear();
+	const month = String(date.getMonth() + 1).padStart(2, "0");
+	const day = String(date.getDate()).padStart(2, "0");
+	return `${year}-${month}-${day}`;
+}
+
+function extensionFor(mimeType: string | null, path: string): string {
+	const fromPath = extname(path);
+	if (fromPath) return fromPath.toLowerCase();
+	switch (mimeType) {
+		case "image/jpeg":
+			return ".jpg";
+		case "image/png":
+			return ".png";
+		case "image/gif":
+			return ".gif";
+		case "image/webp":
+			return ".webp";
+		case "image/heic":
+			return ".heic";
+		case "image/heif":
+			return ".heif";
+		default:
+			return ".img";
+	}
+}
+
+function safeSegment(value: string): string {
+	return value.replace(/[^a-zA-Z0-9._+-]+/g, "_").slice(0, 80) || "unknown";
+}
+
 // ── ChatStore ─────────────────────────────────────────────────────────────────
 
 export interface ChatStoreConfig {
 	workingDir: string;
 }
 
+export interface ArchivedImageRecord {
+	date: string;
+	day: string;
+	sender: string;
+	chatGuid: string;
+	originalPath: string;
+	archivedPath: string;
+	mimeType: string | null;
+	sha256: string;
+	sizeBytes: number;
+	text: string | null;
+}
+
 export interface ChatStore {
 	log(chatGuid: string, message: Omit<Message, "date">): Promise<void>;
+	archiveImages(chatGuid: string, incoming: IncomingMessage): Promise<ArchivedImageRecord[]>;
 }
 
 export function createChatStore(config: ChatStoreConfig): ChatStore {
@@ -85,9 +132,57 @@ export function createChatStore(config: ChatStoreConfig): ChatStore {
 		await appendFile(logPath(chatGuid), `${JSON.stringify(message)}\n`, "utf-8");
 	}
 
+	async function archiveImages(chatGuid: string, incoming: IncomingMessage): Promise<ArchivedImageRecord[]> {
+		const now = new Date();
+		const date = now.toISOString();
+		const day = localDay(now);
+		const imageDir = join(chatDir(chatGuid), "images", day);
+		mkdirSync(imageDir, { recursive: true });
+
+		const records: ArchivedImageRecord[] = [];
+		for (const attachment of incoming.attachments) {
+			if (!attachment.mimeType?.startsWith("image/")) continue;
+
+			const originalPath = attachment.path;
+			const bytes = await readFile(originalPath);
+			const sha256 = createHash("sha256").update(bytes).digest("hex");
+			const extension = extensionFor(attachment.mimeType, originalPath);
+			const filename = `${date.replace(/[:.]/g, "-")}-${safeSegment(incoming.sender)}-${sha256.slice(0, 12)}${extension}`;
+			const archivedAbsPath = join(imageDir, filename);
+			if (!existsSync(archivedAbsPath)) {
+				await copyFile(attachment.path, archivedAbsPath);
+			}
+
+			const sizeBytes = (await stat(archivedAbsPath)).size;
+			const archivedPath = relative(workingDir, archivedAbsPath);
+			attachment.path = archivedAbsPath;
+
+			records.push({
+				date,
+				day,
+				sender: incoming.sender,
+				chatGuid,
+				originalPath,
+				archivedPath,
+				mimeType: attachment.mimeType,
+				sha256,
+				sizeBytes,
+				text: incoming.text,
+			});
+		}
+
+		if (records.length > 0) {
+			const indexPath = join(chatDir(chatGuid), "images", "index.jsonl");
+			await appendFile(indexPath, records.map((record) => JSON.stringify(record)).join("\n") + "\n", "utf-8");
+		}
+
+		return records;
+	}
+
 	return {
 		async log(chatGuid: string, message: Omit<Message, "date">): Promise<void> {
 			await append(chatGuid, { date: new Date().toISOString(), ...message });
 		},
+		archiveImages,
 	};
 }

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -6,6 +6,7 @@
  * before:
  *   logIncoming      — logs the received message
  *   dropSelfEcho     — drops messages that are echoes of the bot's own replies
+ *   archiveImages    — copies image attachments into chat/images/YYYY-MM-DD
  *   storeIncoming    — persists the incoming message to log.jsonl
  *   checkReplyEnabled — drops messages when reply is disabled by settings
  *   downloadImages   — reads image attachments from disk and populates incoming.images
@@ -77,6 +78,21 @@ export function createLogIncomingTask(digestLogger: DigestLogger): BeforeTask {
 		digestLogger.log(
 			`[sid] <- [${label}] ${target}: ${(incoming.text ?? "(attachment)").substring(0, 80)}${attachmentNote}`
 		);
+		return outgoing;
+	};
+}
+
+/** Copy image attachments into the chat workspace and update their paths before logging/reading. */
+export function createArchiveImagesTask(store: ChatStore): BeforeTask {
+	return async (chat, incoming, outgoing) => {
+		try {
+			const archived = await store.archiveImages(chat.chatGuid, incoming);
+			if (archived.length > 0) {
+				console.log(`[sid] archived ${archived.length} image(s) for ${chat.chatGuid}`);
+			}
+		} catch (error) {
+			console.error(`[sid] failed to archive image attachments for ${chat.chatGuid}:`, error);
+		}
 		return outgoing;
 	};
 }


### PR DESCRIPTION
## Summary
- copy incoming image attachments into per-chat images/YYYY-MM-DD folders
- append image metadata to per-chat images/index.jsonl
- update incoming attachment paths before logging/model image processing

## Test
- npm run typecheck
- npm test
- npm run build