### PR TITLE
feat: add namespace-based structured memory tools

### DIFF
--- a/docs/structured-memory-sequence.md
+++ b/docs/structured-memory-sequence.md
@@ -1,0 +1,85 @@
+# Structured memory read/write sequence
+
+Design goals:
+
+- The LLM understands and classifies natural language; the storage CLI only validates and persists structured records.
+- Category is metadata, not a keyword-based retrieval gate.
+- Category JSONL files are the structured source of truth. Semantic indexes and summaries are derived and rebuildable.
+- Legacy `MEMORY.md` files are read-only migration archives.
+
+## Read flow
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor U as User / Chat
+    participant P as pi-imessage
+    participant R as Memory Reader
+    participant S as JSONL Store
+    participant I as Semantic Index
+    participant L as LLM Reranker
+    participant A as Main LLM
+
+    U->>P: Incoming message
+    Note over P: Load small core.md (always-on)
+    P->>R: Query + sender/chat context
+    R->>S: Load active records / resolve supersedes
+    S-->>R: Active memory records
+    R->>I: Semantic top-K recall
+    I-->>R: Candidate memory IDs + scores
+    opt Low-confidence or high-stakes query
+        R->>L: Query + candidate records
+        L-->>R: Relevance-ranked top-N
+    end
+    R-->>P: Compact relevant memory context
+    P->>A: core.md + relevant records + current message
+    A-->>P: Answer
+    P-->>U: iMessage reply
+```
+
+## Write flow
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor U as User / Chat
+    participant P as pi-imessage
+    participant A as Main LLM
+    participant C as Memory CLI
+    participant S as JSONL Store
+    participant I as Semantic Index
+
+    U->>P: Incoming message
+    P->>P: Append raw event to log.jsonl
+    P->>A: Current message + retrieved context
+    A->>A: Decide should_remember
+    alt Not durable / duplicate / uncertain
+        A-->>P: Skip memory write
+    else Durable memory
+        A->>A: Produce structured record<br/>text, category, subjects, event_time,<br/>source, importance, confidence, supersedes
+        A->>C: add(structured record)
+        C->>C: Schema validation + ID generation<br/>dedupe + supersedes validation
+        C->>S: Append to categories/*.jsonl
+        S-->>C: Stored record ID
+        C-->>I: Async/incremental index refresh
+        C-->>A: Stored / already exists
+    end
+    A-->>P: Answer
+    P-->>U: iMessage reply
+```
+
+## Responsibility boundaries
+
+| Component | Responsibility | Must not do |
+| --- | --- | --- |
+| Main LLM | Decide whether a fact is durable; extract atomic text, category, subjects, date, source and correction relationship | Silently overwrite history |
+| Memory CLI | Validate schema, generate deterministic IDs, deduplicate and append/supersede records | Interpret natural language with fixed keyword lists |
+| JSONL store | Preserve auditable structured memory history | Act as a generated cache |
+| Semantic index | Retrieve candidates by meaning | Become a source of truth |
+| LLM reranker | Resolve ambiguous relevance when needed | Run unconditionally if semantic scores are already decisive |
+
+Open review decisions:
+
+1. Use local embeddings or a hosted embedding model for the derived semantic index.
+2. Invoke the LLM reranker only below a confidence threshold, or on every read.
+3. Refresh the semantic index synchronously after a write, or asynchronously in a short debounce window.

--- a/docs/structured-memory-sequence.md
+++ b/docs/structured-memory-sequence.md
@@ -1,6 +1,6 @@
-# Structured memory sequence flow
+# Structured Memory Sequence Flow
 
-整体分为四部分：一次性全量迁移、运行时动态读取、运行时主动写入、每日夜间 Reflection。
+The design has four parts: one-time full migration, runtime reads, runtime writes, and nightly reflection.
 
 ## 1. One-time full migration
 
@@ -16,32 +16,32 @@ sequenceDiagram
     participant M as Coverage Manifest
     participant R as Runtime
 
-    O->>P: 读取全部 section、bullet 和多行内容
+    O->>P: Read every section, bullet, and multiline block
     P-->>L: Source blocks<br/>path + line range + source hash
-    V->>L: 补充仅存在于 v1 的 native records
+    V->>L: Add native records that exist only in v1
 
     loop Batch classification and extraction
-        L->>L: 拆分原子事实<br/>namespace + kind + subjects + event_time
+        L->>L: Extract atomic facts<br/>namespace + kind + subjects + event_time
         L->>C: Structured records + block decisions
-        C->>C: Schema、ID、来源、引用和重复校验
-        C->>N: 写入通过校验的 records
-        C->>M: block -> memory IDs 或 skipped_reason
+        C->>C: Validate schema, IDs, sources, references, and duplicates
+        C->>N: Write valid records
+        C->>M: Map block to memory IDs or skipped_reason
     end
 
-    C->>M: 检查每个 source block 都有处理结果
+    C->>M: Verify that every source block has an outcome
     M-->>C: Coverage = 100%
-    C->>N: 验证 supersedes、active view 和文件完整性
-    C->>R: Atomic cutover to v2
+    C->>N: Validate supersedes, active view, and file integrity
+    C->>R: Atomically cut over to v2
 
-    Note over O,V: 原文件和 v1 保留为只读归档，不直接删除
+    Note over O,V: Keep the original files and v1 as read-only archives
 ```
 
-迁移原则：
+Migration rules:
 
-- “全量”指每个原文 block 都被处理并可追踪，不代表每一行都必须生成一条记忆。
-- 无法确认事实日期时使用 `event_time: null`，不伪造日期。
-- `namespace` 是运行时加载单元，例如 `health/paipai`、`work/cc`、`project/pi-imessage`。
-- `kind` 描述记录类型，例如 `fact`、`event`、`preference`、`procedure`。
+- "Full" means every source block is processed and traceable; it does not mean every line must become a memory record.
+- Use `event_time: null` when the factual date is unknown. Never invent a date.
+- `namespace` is the runtime loading unit, for example `health/paipai`, `work/cc`, or `project/pi-imessage`.
+- `kind` describes the record type, for example `fact`, `event`, `preference`, or `procedure`.
 
 ## 2. Runtime read
 
@@ -54,19 +54,19 @@ sequenceDiagram
     participant M as Memory Tool
     participant S as v2 JSONL
 
-    Note over P,A: Session 初始只包含小型 core.md
+    Note over P,A: A session starts with only the small core.md
     U->>P: Incoming message
     P->>A: Current message
-    A->>A: 根据对话选择相关 namespace<br/>可多选，也可以不选
+    A->>A: Select relevant namespaces from the conversation<br/>May select multiple or none
 
-    opt 需要历史记忆
+    opt Historical memory is needed
         A->>M: load_memory(namespaces)
-        M->>S: 读取所选 namespace 的全部 active records
+        M->>S: Read all active records in selected namespaces
         S-->>M: Current records
-        M-->>A: 完整 namespace context
+        M-->>A: Complete namespace context
     end
 
-    Note over A: Main LLM 自己判断哪些记录与当前问题相关
+    Note over A: The Main LLM decides which records matter to the current request
     A-->>P: Answer
     P-->>U: iMessage reply
 ```
@@ -85,19 +85,19 @@ sequenceDiagram
     U->>P: Incoming message
     P->>P: Append raw event to log.jsonl
     P->>A: Current message
-    A->>A: 判断是否值得长期记忆
+    A->>A: Decide whether the information is durable
 
-    alt 不值得记、重复或不确定
-        A-->>P: 直接回答
-    else 值得记忆
-        A->>A: 生成结构化记录<br/>text, namespace, kind, subjects,<br/>event_time, source, importance, confidence
-        opt 纠正旧事实
+    alt Not durable, duplicate, or uncertain
+        A-->>P: Answer without writing memory
+    else Durable memory
+        A->>A: Produce a structured record<br/>text, namespace, kind, subjects,<br/>event_time, source, importance, confidence
+        opt Corrects an older fact
             A->>M: search_memory(old fact)
             M-->>A: Old memory ID
-            A->>A: 设置 supersedes_id
+            A->>A: Set supersedes_id
         end
         A->>M: save_memory(structured record)
-        M->>M: Schema、去重和 supersedes 校验
+        M->>M: Validate schema, deduplication, and supersedes
         M->>S: Append JSONL
         S-->>M: Stored record ID
         M-->>A: Stored / already exists
@@ -119,48 +119,48 @@ sequenceDiagram
     participant M as Memory Tool
     participant S as v2 JSONL
 
-    C->>K: 读取上次成功处理的位置
+    C->>K: Read the last successful processing position
     K-->>C: Last processed message IDs / timestamps
-    C->>G: 读取各 Chat 尚未处理的消息
-    G-->>R: 按对话窗口分批提供原始消息
+    C->>G: Read unprocessed messages from every chat
+    G-->>R: Provide raw messages in conversation windows
 
-    R->>R: Reflection<br/>遗漏的长期事实、偏好、纠错和关系变化
+    R->>R: Reflect on missed durable facts,<br/>preferences, corrections, and relationship changes
     R->>M: load_memory(relevant namespaces)
-    M->>S: 读取对应 active records
+    M->>S: Read relevant active records
     S-->>M: Existing memory
-    M-->>R: 用于去重和识别纠错
+    M-->>R: Context for deduplication and correction detection
 
-    loop 每条值得保留的候选记忆
+    loop Each durable memory candidate
         R->>M: save_memory(structured record)
-        M->>M: Schema、去重和 supersedes 校验
+        M->>M: Validate schema, deduplication, and supersedes
         M->>S: Append JSONL
         S-->>M: Stored / already exists
         M-->>R: Result
     end
 
-    alt 本批全部成功
-        R->>K: 提交新的 checkpoint
+    alt Entire batch succeeds
+        R->>K: Commit the new checkpoint
         R-->>C: Reflection summary
-    else 处理中断
-        R-->>C: 报告失败，不推进 checkpoint
+    else Processing fails
+        R-->>C: Report failure without advancing the checkpoint
     end
 ```
 
-Reflection 原则：
+Reflection rules:
 
-- 运行时写入负责及时记录，夜间 Reflection 负责补漏、去重和识别跨消息形成的事实。
-- 使用 checkpoint，而不是每天盲扫固定 48 小时；失败时不推进，下一次可安全重试。
-- Reflection 与聊天时写入共用同一个 `save_memory` 路径，不直接修改 JSONL，也不写旧 `MEMORY.md`。
-- 不把每天聊天摘要整体存成记忆，只保存长期有用的原子事实。
+- Runtime writes capture facts promptly; nightly reflection catches omissions, deduplicates, and identifies facts that emerge across multiple messages.
+- Use a checkpoint instead of blindly rescanning a fixed 48-hour window. Do not advance it after a failed run, so retries remain safe.
+- Reflection and runtime writes share the same `save_memory` path. Neither writes directly to JSONL or legacy `MEMORY.md` files.
+- Do not store a whole daily chat summary as memory. Store only durable atomic facts.
 
 ## Responsibility boundaries
 
-- Main LLM：理解自然语言、选择 namespace、决定是否记忆并生成结构化字段。
-- Reflection LLM：夜间扫描未处理对话，补漏、去重并识别跨消息形成的记忆。
-- Memory Tool：只做读取、校验、去重、append 和 supersedes，不用关键词理解自然语言。
-- v2 JSONL：唯一的结构化 memory source of truth。
-- Coverage Manifest：证明旧 MEMORY.md 没有被静默漏迁。
-- Reflection Checkpoint：保证夜间任务可重试且不会静默跳过消息。
-- `core.md`：只保存少量稳定、高频信息。
-- Legacy MEMORY.md / v1 JSONL：迁移完成后只读归档。
-- 不使用固定关键词分类、Semantic Index、embedding 或 reranker。
+- Main LLM: understand natural language, select namespaces, decide whether to remember, and produce structured fields.
+- Reflection LLM: inspect unprocessed conversations nightly, catch omissions, deduplicate, and identify facts that emerge across messages.
+- Memory Tool: read, validate, deduplicate, append, and apply superseding corrections without interpreting natural language through keyword lists.
+- v2 JSONL: the sole structured-memory source of truth.
+- Coverage Manifest: proves that no legacy `MEMORY.md` source block was silently skipped.
+- Reflection Checkpoint: makes nightly processing retryable and prevents silent message loss.
+- `core.md`: contains only a small set of stable, frequently needed facts.
+- Legacy `MEMORY.md` and v1 JSONL: read-only archives after migration.
+- No fixed keyword classifier, semantic index, embedding store, or reranker is used.

--- a/docs/structured-memory-sequence.md
+++ b/docs/structured-memory-sequence.md
@@ -1,10 +1,49 @@
-# Structured memory read/write sequence
+# Structured memory sequence flow
 
-第一版采用 Category 级动态加载：不在 Session 启动时加载全部记忆，也不做关键词路由或单条记录的语义检索。
+整体分为三部分：一次性全量迁移、运行时动态读取、运行时主动写入。
 
-Category 由正在聊天的 Main LLM 根据上下文选择；Memory Tool 只按选择结果读取对应 JSONL。
+## 1. One-time full migration
 
-## Read flow
+```mermaid
+sequenceDiagram
+    autonumber
+    participant O as Legacy MEMORY.md
+    participant V as Existing v1 JSONL
+    participant P as Markdown Block Parser
+    participant L as Migration LLM
+    participant C as Validator
+    participant N as Staging v2 JSONL
+    participant M as Coverage Manifest
+    participant R as Runtime
+
+    O->>P: 读取全部 section、bullet 和多行内容
+    P-->>L: Source blocks<br/>path + line range + source hash
+    V->>L: 补充仅存在于 v1 的 native records
+
+    loop Batch classification and extraction
+        L->>L: 拆分原子事实<br/>namespace + kind + subjects + event_time
+        L->>C: Structured records + block decisions
+        C->>C: Schema、ID、来源、引用和重复校验
+        C->>N: 写入通过校验的 records
+        C->>M: block -> memory IDs 或 skipped_reason
+    end
+
+    C->>M: 检查每个 source block 都有处理结果
+    M-->>C: Coverage = 100%
+    C->>N: 验证 supersedes、active view 和文件完整性
+    C->>R: Atomic cutover to v2
+
+    Note over O,V: 原文件和 v1 保留为只读归档，不直接删除
+```
+
+迁移原则：
+
+- “全量”指每个原文 block 都被处理并可追踪，不代表每一行都必须生成一条记忆。
+- 无法确认事实日期时使用 `event_time: null`，不伪造日期。
+- `namespace` 是运行时加载单元，例如 `health/paipai`、`work/cc`、`project/pi-imessage`。
+- `kind` 描述记录类型，例如 `fact`、`event`、`preference`、`procedure`。
+
+## 2. Runtime read
 
 ```mermaid
 sequenceDiagram
@@ -13,26 +52,26 @@ sequenceDiagram
     participant P as pi-imessage
     participant A as Main LLM
     participant M as Memory Tool
-    participant S as categories/*.jsonl
+    participant S as v2 JSONL
 
     Note over P,A: Session 初始只包含小型 core.md
     U->>P: Incoming message
     P->>A: Current message
-    A->>A: 判断需要哪些 Category<br/>可多选，也可以不选
+    A->>A: 根据对话选择相关 namespace<br/>可多选，也可以不选
 
     opt 需要历史记忆
-        A->>M: load_categories([health, person, ...])
-        M->>S: 读取所选 Category 的全部有效记录
-        S-->>M: Active records
-        M-->>A: 完整 Category memory context
+        A->>M: load_memory(namespaces)
+        M->>S: 读取所选 namespace 的全部 active records
+        S-->>M: Current records
+        M-->>A: 完整 namespace context
     end
 
-    Note over A: LLM 自己从 Category 全集里判断相关事实
+    Note over A: Main LLM 自己判断哪些记录与当前问题相关
     A-->>P: Answer
     P-->>U: iMessage reply
 ```
 
-## Write flow
+## 3. Runtime write
 
 ```mermaid
 sequenceDiagram
@@ -41,19 +80,24 @@ sequenceDiagram
     participant P as pi-imessage
     participant A as Main LLM
     participant M as Memory Tool
-    participant S as categories/*.jsonl
+    participant S as v2 JSONL
 
     U->>P: Incoming message
     P->>P: Append raw event to log.jsonl
     P->>A: Current message
     A->>A: 判断是否值得长期记忆
 
-    alt 不值得记 / 重复 / 不确定
-        A-->>P: 直接回答，不写 memory
+    alt 不值得记、重复或不确定
+        A-->>P: 直接回答
     else 值得记忆
-        A->>A: 生成结构化记录<br/>text, category, subjects, event_time,<br/>source, importance, confidence, supersedes
+        A->>A: 生成结构化记录<br/>text, namespace, kind, subjects,<br/>event_time, source, importance, confidence
+        opt 纠正旧事实
+            A->>M: search_memory(old fact)
+            M-->>A: Old memory ID
+            A->>A: 设置 supersedes_id
+        end
         A->>M: save_memory(structured record)
-        M->>M: Schema 校验、去重、校验 supersedes
+        M->>M: Schema、去重和 supersedes 校验
         M->>S: Append JSONL
         S-->>M: Stored record ID
         M-->>A: Stored / already exists
@@ -63,11 +107,12 @@ sequenceDiagram
     P-->>U: iMessage reply
 ```
 
-## 关键点
+## Responsibility boundaries
 
-- Main LLM 通过 typed tool 自己选择一个或多个 Category，不需要额外的 classifier LLM。
-- Memory Tool 的 Category 参数使用固定 enum，但分类判断来自 LLM，不来自关键词表。
-- `load_categories` 返回所选 Category 下的全部有效记录，不做单条记录筛选。
-- 同一 Session 已加载过的 Category 不重复注入；文件有更新时只补充 delta，避免 context 线性膨胀。
-- JSONL 是 source of truth；`core.md` 只放少量稳定、高频信息；旧 `MEMORY.md` 只读。
+- Main LLM：理解自然语言、选择 namespace、决定是否记忆并生成结构化字段。
+- Memory Tool：只做读取、校验、去重、append 和 supersedes，不用关键词理解自然语言。
+- v2 JSONL：唯一的结构化 memory source of truth。
+- Coverage Manifest：证明旧 MEMORY.md 没有被静默漏迁。
+- `core.md`：只保存少量稳定、高频信息。
+- Legacy MEMORY.md / v1 JSONL：迁移完成后只读归档。
 - 不使用固定关键词分类、Semantic Index、embedding 或 reranker。

--- a/docs/structured-memory-sequence.md
+++ b/docs/structured-memory-sequence.md
@@ -1,6 +1,6 @@
 # Structured memory sequence flow
 
-整体分为三部分：一次性全量迁移、运行时动态读取、运行时主动写入。
+整体分为四部分：一次性全量迁移、运行时动态读取、运行时主动写入、每日夜间 Reflection。
 
 ## 1. One-time full migration
 
@@ -107,12 +107,60 @@ sequenceDiagram
     P-->>U: iMessage reply
 ```
 
+## 4. Nightly reflection
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant C as Nightly Cron
+    participant K as Reflection Checkpoint
+    participant G as Chat log.jsonl
+    participant R as Reflection LLM
+    participant M as Memory Tool
+    participant S as v2 JSONL
+
+    C->>K: 读取上次成功处理的位置
+    K-->>C: Last processed message IDs / timestamps
+    C->>G: 读取各 Chat 尚未处理的消息
+    G-->>R: 按对话窗口分批提供原始消息
+
+    R->>R: Reflection<br/>遗漏的长期事实、偏好、纠错和关系变化
+    R->>M: load_memory(relevant namespaces)
+    M->>S: 读取对应 active records
+    S-->>M: Existing memory
+    M-->>R: 用于去重和识别纠错
+
+    loop 每条值得保留的候选记忆
+        R->>M: save_memory(structured record)
+        M->>M: Schema、去重和 supersedes 校验
+        M->>S: Append JSONL
+        S-->>M: Stored / already exists
+        M-->>R: Result
+    end
+
+    alt 本批全部成功
+        R->>K: 提交新的 checkpoint
+        R-->>C: Reflection summary
+    else 处理中断
+        R-->>C: 报告失败，不推进 checkpoint
+    end
+```
+
+Reflection 原则：
+
+- 运行时写入负责及时记录，夜间 Reflection 负责补漏、去重和识别跨消息形成的事实。
+- 使用 checkpoint，而不是每天盲扫固定 48 小时；失败时不推进，下一次可安全重试。
+- Reflection 与聊天时写入共用同一个 `save_memory` 路径，不直接修改 JSONL，也不写旧 `MEMORY.md`。
+- 不把每天聊天摘要整体存成记忆，只保存长期有用的原子事实。
+
 ## Responsibility boundaries
 
 - Main LLM：理解自然语言、选择 namespace、决定是否记忆并生成结构化字段。
+- Reflection LLM：夜间扫描未处理对话，补漏、去重并识别跨消息形成的记忆。
 - Memory Tool：只做读取、校验、去重、append 和 supersedes，不用关键词理解自然语言。
 - v2 JSONL：唯一的结构化 memory source of truth。
 - Coverage Manifest：证明旧 MEMORY.md 没有被静默漏迁。
+- Reflection Checkpoint：保证夜间任务可重试且不会静默跳过消息。
 - `core.md`：只保存少量稳定、高频信息。
 - Legacy MEMORY.md / v1 JSONL：迁移完成后只读归档。
 - 不使用固定关键词分类、Semantic Index、embedding 或 reranker。

--- a/docs/structured-memory-sequence.md
+++ b/docs/structured-memory-sequence.md
@@ -1,38 +1,28 @@
 # Structured memory read/write sequence
 
-Design goals:
+第一版采用全量加载，不做关键词路由、Semantic Index 或 LLM rerank。
 
-- The LLM understands and classifies natural language; the storage CLI only validates and persists structured records.
-- Category is metadata, not a keyword-based retrieval gate.
-- Category JSONL files are the structured source of truth. Semantic indexes and summaries are derived and rebuildable.
-- Legacy `MEMORY.md` files are read-only migration archives.
+当前约 490 条有效记录，紧凑文本约 5.8 万字符（约 2–3 万 tokens）。只在 session 创建时加载一次，不在每轮消息中重复注入。
 
 ## Read flow
 
 ```mermaid
 sequenceDiagram
     autonumber
-    actor U as User / Chat
     participant P as pi-imessage
-    participant R as Memory Reader
-    participant S as JSONL Store
-    participant I as Semantic Index
-    participant L as LLM Reranker
-    participant A as Main LLM
+    participant S as categories/*.jsonl
+    participant A as Main LLM Session
+    actor U as User / Chat
 
+    Note over P,A: Session 创建
+    P->>S: 读取全部当前有效记录
+    S-->>P: 紧凑 memory context
+    P->>A: 创建 Session<br/>system prompt = core.md + 全部 active memory
+
+    Note over U,A: 后续每条消息不再重复注入 memory
     U->>P: Incoming message
-    Note over P: Load small core.md (always-on)
-    P->>R: Query + sender/chat context
-    R->>S: Load active records / resolve supersedes
-    S-->>R: Active memory records
-    R->>I: Semantic top-K recall
-    I-->>R: Candidate memory IDs + scores
-    opt Low-confidence or high-stakes query
-        R->>L: Query + candidate records
-        L-->>R: Relevance-ranked top-N
-    end
-    R-->>P: Compact relevant memory context
-    P->>A: core.md + relevant records + current message
+    P->>A: Current message
+    Note over A: LLM 直接从完整 memory context 判断相关性
     A-->>P: Answer
     P-->>U: iMessage reply
 ```
@@ -44,42 +34,37 @@ sequenceDiagram
     autonumber
     actor U as User / Chat
     participant P as pi-imessage
-    participant A as Main LLM
+    participant A as Main LLM Session
     participant C as Memory CLI
-    participant S as JSONL Store
-    participant I as Semantic Index
+    participant S as categories/*.jsonl
 
     U->>P: Incoming message
     P->>P: Append raw event to log.jsonl
-    P->>A: Current message + retrieved context
-    A->>A: Decide should_remember
-    alt Not durable / duplicate / uncertain
-        A-->>P: Skip memory write
-    else Durable memory
-        A->>A: Produce structured record<br/>text, category, subjects, event_time,<br/>source, importance, confidence, supersedes
+    P->>A: Current message
+    A->>A: 判断是否值得长期记忆
+
+    alt 不值得记 / 重复 / 不确定
+        A-->>P: 直接回答，不写 memory
+    else 值得记忆
+        A->>A: 生成结构化记录<br/>text, category, subjects, event_time,<br/>source, importance, confidence, supersedes
         A->>C: add(structured record)
-        C->>C: Schema validation + ID generation<br/>dedupe + supersedes validation
-        C->>S: Append to categories/*.jsonl
+        C->>C: Schema 校验、去重、校验 supersedes
+        C->>S: Append JSONL
         S-->>C: Stored record ID
-        C-->>I: Async/incremental index refresh
         C-->>A: Stored / already exists
+        Note over A: 当前 Session 已通过 tool call 知道新记录
+        A-->>P: Answer
     end
-    A-->>P: Answer
+
     P-->>U: iMessage reply
+    Note over P,S: 新 Session 会重新加载最新全集
 ```
 
-## Responsibility boundaries
+## 边界
 
-| Component | Responsibility | Must not do |
-| --- | --- | --- |
-| Main LLM | Decide whether a fact is durable; extract atomic text, category, subjects, date, source and correction relationship | Silently overwrite history |
-| Memory CLI | Validate schema, generate deterministic IDs, deduplicate and append/supersede records | Interpret natural language with fixed keyword lists |
-| JSONL store | Preserve auditable structured memory history | Act as a generated cache |
-| Semantic index | Retrieve candidates by meaning | Become a source of truth |
-| LLM reranker | Resolve ambiguous relevance when needed | Run unconditionally if semantic scores are already decisive |
-
-Open review decisions:
-
-1. Use local embeddings or a hosted embedding model for the derived semantic index.
-2. Invoke the LLM reranker only below a confidence threshold, or on every read.
-3. Refresh the semantic index synchronously after a write, or asynchronously in a short debounce window.
+- Main LLM：理解自然语言，决定是否记忆，并生成 Category、Subjects 等结构化字段。
+- Memory CLI：只做确定性的校验、去重和持久化，不用关键词理解自然语言。
+- JSONL：结构化记忆的 source of truth。
+- `core.md`：只放少量稳定且高频的信息。
+- `MEMORY.md`：只读迁移归档。
+- 不使用固定关键词分类、Semantic Index、embedding 或额外 reranker。

--- a/docs/structured-memory-sequence.md
+++ b/docs/structured-memory-sequence.md
@@ -1,28 +1,33 @@
 # Structured memory read/write sequence
 
-第一版采用全量加载，不做关键词路由、Semantic Index 或 LLM rerank。
+第一版采用 Category 级动态加载：不在 Session 启动时加载全部记忆，也不做关键词路由或单条记录的语义检索。
 
-当前约 490 条有效记录，紧凑文本约 5.8 万字符（约 2–3 万 tokens）。只在 session 创建时加载一次，不在每轮消息中重复注入。
+Category 由正在聊天的 Main LLM 根据上下文选择；Memory Tool 只按选择结果读取对应 JSONL。
 
 ## Read flow
 
 ```mermaid
 sequenceDiagram
     autonumber
-    participant P as pi-imessage
-    participant S as categories/*.jsonl
-    participant A as Main LLM Session
     actor U as User / Chat
+    participant P as pi-imessage
+    participant A as Main LLM
+    participant M as Memory Tool
+    participant S as categories/*.jsonl
 
-    Note over P,A: Session 创建
-    P->>S: 读取全部当前有效记录
-    S-->>P: 紧凑 memory context
-    P->>A: 创建 Session<br/>system prompt = core.md + 全部 active memory
-
-    Note over U,A: 后续每条消息不再重复注入 memory
+    Note over P,A: Session 初始只包含小型 core.md
     U->>P: Incoming message
     P->>A: Current message
-    Note over A: LLM 直接从完整 memory context 判断相关性
+    A->>A: 判断需要哪些 Category<br/>可多选，也可以不选
+
+    opt 需要历史记忆
+        A->>M: load_categories([health, person, ...])
+        M->>S: 读取所选 Category 的全部有效记录
+        S-->>M: Active records
+        M-->>A: 完整 Category memory context
+    end
+
+    Note over A: LLM 自己从 Category 全集里判断相关事实
     A-->>P: Answer
     P-->>U: iMessage reply
 ```
@@ -34,8 +39,8 @@ sequenceDiagram
     autonumber
     actor U as User / Chat
     participant P as pi-imessage
-    participant A as Main LLM Session
-    participant C as Memory CLI
+    participant A as Main LLM
+    participant M as Memory Tool
     participant S as categories/*.jsonl
 
     U->>P: Incoming message
@@ -47,24 +52,22 @@ sequenceDiagram
         A-->>P: 直接回答，不写 memory
     else 值得记忆
         A->>A: 生成结构化记录<br/>text, category, subjects, event_time,<br/>source, importance, confidence, supersedes
-        A->>C: add(structured record)
-        C->>C: Schema 校验、去重、校验 supersedes
-        C->>S: Append JSONL
-        S-->>C: Stored record ID
-        C-->>A: Stored / already exists
-        Note over A: 当前 Session 已通过 tool call 知道新记录
+        A->>M: save_memory(structured record)
+        M->>M: Schema 校验、去重、校验 supersedes
+        M->>S: Append JSONL
+        S-->>M: Stored record ID
+        M-->>A: Stored / already exists
         A-->>P: Answer
     end
 
     P-->>U: iMessage reply
-    Note over P,S: 新 Session 会重新加载最新全集
 ```
 
-## 边界
+## 关键点
 
-- Main LLM：理解自然语言，决定是否记忆，并生成 Category、Subjects 等结构化字段。
-- Memory CLI：只做确定性的校验、去重和持久化，不用关键词理解自然语言。
-- JSONL：结构化记忆的 source of truth。
-- `core.md`：只放少量稳定且高频的信息。
-- `MEMORY.md`：只读迁移归档。
-- 不使用固定关键词分类、Semantic Index、embedding 或额外 reranker。
+- Main LLM 通过 typed tool 自己选择一个或多个 Category，不需要额外的 classifier LLM。
+- Memory Tool 的 Category 参数使用固定 enum，但分类判断来自 LLM，不来自关键词表。
+- `load_categories` 返回所选 Category 下的全部有效记录，不做单条记录筛选。
+- 同一 Session 已加载过的 Category 不重复注入；文件有更新时只补充 delta，避免 context 线性膨胀。
+- JSONL 是 source of truth；`core.md` 只放少量稳定、高频信息；旧 `MEMORY.md` 只读。
+- 不使用固定关键词分类、Semantic Index、embedding 或 reranker。

--- a/src/__tests__/memory.test.ts
+++ b/src/__tests__/memory.test.ts
@@ -1,0 +1,73 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { formatStructuredMemory, readCoreMemory, retrieveStructuredMemory } from "../memory.js";
+
+function fixture(): string {
+	const root = mkdtempSync(join(tmpdir(), "pi-memory-"));
+	const memoryRoot = join(root, "skills", "file-memory");
+	mkdirSync(join(memoryRoot, "categories"), { recursive: true });
+	writeFileSync(join(memoryRoot, "core.md"), "stable core fact\n");
+	const records = [
+		{
+			id: "old",
+			text: "派派肺炎住院",
+			category: "health",
+			subjects: ["派派"],
+			event_time: "2026-07-02",
+			importance: 0.9,
+			confidence: 1,
+			status: "active",
+		},
+		{
+			id: "new",
+			text: "派派因腺病毒肺炎住院",
+			category: "health",
+			subjects: ["派派"],
+			event_time: "2026-07-02",
+			importance: 0.9,
+			confidence: 1,
+			status: "active",
+			supersedes_id: "old",
+		},
+		{
+			id: "cc",
+			text: "CC发烧",
+			category: "health",
+			subjects: ["CC"],
+			event_time: "2026-07-03",
+			importance: 0.6,
+			confidence: 0.8,
+			status: "active",
+		},
+	];
+	writeFileSync(
+		join(memoryRoot, "categories", "health.jsonl"),
+		`${records.map((x) => JSON.stringify(x)).join("\n")}\n`
+	);
+	return root;
+}
+
+describe("structured memory", () => {
+	it("reads small always-on core memory", () => {
+		expect(readCoreMemory(fixture())).toBe("stable core fact");
+	});
+
+	it("retrieves the right subject and hides superseded records", () => {
+		const items = retrieveStructuredMemory(fixture(), "派派上次肺炎住院是什么时候");
+		expect(items.map((item) => item.id)).toEqual(["new"]);
+	});
+
+	it("formats retrieved records for prompt injection", () => {
+		const items = retrieveStructuredMemory(fixture(), "CC发烧");
+		const formatted = formatStructuredMemory(items);
+		expect(formatted).toContain("active records only");
+		expect(formatted).toContain("CC发烧");
+		expect(formatted).not.toContain("派派");
+	});
+
+	it("does not retrieve from transport metadata alone", () => {
+		expect(retrieveStructuredMemory(fixture(), "[DM from +8617612150403] 继续？")).toEqual([]);
+	});
+});

--- a/src/__tests__/memory.test.ts
+++ b/src/__tests__/memory.test.ts
@@ -2,72 +2,112 @@ import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
-import { formatStructuredMemory, readCoreMemory, retrieveStructuredMemory } from "../memory.js";
+import { listMemoryNamespaces, loadMemoryNamespaces, readCoreMemory, saveMemory, searchMemory } from "../memory.js";
+
+function record(overrides: Record<string, unknown>) {
+	return {
+		id: "base",
+		text: "base fact",
+		namespace: "health/paipai",
+		kind: "event",
+		subjects: ["派派"],
+		event_time: "2026-07-02",
+		sources: [{ type: "test", label: "fixture" }],
+		importance: 0.9,
+		confidence: 1,
+		status: "active",
+		created_at: "2026-07-02T00:00:00Z",
+		...overrides,
+	};
+}
 
 function fixture(): string {
 	const root = mkdtempSync(join(tmpdir(), "pi-memory-"));
 	const memoryRoot = join(root, "skills", "file-memory");
-	mkdirSync(join(memoryRoot, "categories"), { recursive: true });
+	mkdirSync(join(memoryRoot, "namespaces", "health"), { recursive: true });
+	mkdirSync(join(memoryRoot, "namespaces", "work"), { recursive: true });
 	writeFileSync(join(memoryRoot, "core.md"), "stable core fact\n");
-	const records = [
-		{
-			id: "old",
-			text: "派派肺炎住院",
-			category: "health",
-			subjects: ["派派"],
-			event_time: "2026-07-02",
-			importance: 0.9,
-			confidence: 1,
-			status: "active",
-		},
-		{
-			id: "new",
-			text: "派派因腺病毒肺炎住院",
-			category: "health",
-			subjects: ["派派"],
-			event_time: "2026-07-02",
-			importance: 0.9,
-			confidence: 1,
-			status: "active",
-			supersedes_id: "old",
-		},
-		{
+	const health = [
+		record({ id: "old", text: "派派肺炎住院" }),
+		record({ id: "new", text: "派派因腺病毒肺炎住院", supersedes_id: "old" }),
+		record({
 			id: "cc",
 			text: "CC发烧",
-			category: "health",
+			namespace: "health/cc",
 			subjects: ["CC"],
 			event_time: "2026-07-03",
-			importance: 0.6,
-			confidence: 0.8,
-			status: "active",
-		},
+		}),
 	];
 	writeFileSync(
-		join(memoryRoot, "categories", "health.jsonl"),
-		`${records.map((x) => JSON.stringify(x)).join("\n")}\n`
+		join(memoryRoot, "namespaces", "health", "paipai.jsonl"),
+		`${health
+			.slice(0, 2)
+			.map((item) => JSON.stringify(item))
+			.join("\n")}\n`
+	);
+	writeFileSync(join(memoryRoot, "namespaces", "health", "cc.jsonl"), `${JSON.stringify(health[2])}\n`);
+	writeFileSync(
+		join(memoryRoot, "namespaces", "work", "henry.jsonl"),
+		`${JSON.stringify(record({ id: "work", text: "Henry joined Optiver", namespace: "work/henry", subjects: ["Henry"] }))}\n`
 	);
 	return root;
 }
 
-describe("structured memory", () => {
+describe("structured memory v2", () => {
 	it("reads small always-on core memory", () => {
 		expect(readCoreMemory(fixture())).toBe("stable core fact");
 	});
 
-	it("retrieves the right subject and hides superseded records", () => {
-		const items = retrieveStructuredMemory(fixture(), "派派上次肺炎住院是什么时候");
+	it("lists namespace loading units with active counts", () => {
+		expect(listMemoryNamespaces(fixture())).toEqual([
+			{ namespace: "health/cc", total: 1, active: 1 },
+			{ namespace: "health/paipai", total: 2, active: 1 },
+			{ namespace: "work/henry", total: 1, active: 1 },
+		]);
+	});
+
+	it("loads complete selected namespaces and hides superseded records", () => {
+		const items = loadMemoryNamespaces(fixture(), ["health/paipai", "health/cc"]);
+		expect(items.map((item) => item.id).sort()).toEqual(["cc", "new"]);
+	});
+
+	it("does not perform automatic query routing but supports explicit correction search", () => {
+		const items = searchMemory(fixture(), "腺病毒", { namespaces: ["health/paipai"] });
 		expect(items.map((item) => item.id)).toEqual(["new"]);
 	});
 
-	it("formats retrieved records for prompt injection", () => {
-		const items = retrieveStructuredMemory(fixture(), "CC发烧");
-		const formatted = formatStructuredMemory(items);
-		expect(formatted).toContain("active records only");
-		expect(formatted).toContain("CC发烧");
-		expect(formatted).not.toContain("派派");
+	it("appends idempotently and preserves a superseding correction", async () => {
+		const root = fixture();
+		const input = {
+			text: "派派已经出院",
+			namespace: "health/paipai",
+			kind: "event" as const,
+			subjects: ["派派"],
+			event_time: "2026-07-05",
+			source: "private chat message on 2026-07-05",
+			importance: 0.9,
+			confidence: 1,
+			supersedes_id: "new",
+		};
+		const first = await saveMemory(root, input);
+		const second = await saveMemory(root, { ...input, source: "same fact repeated later" });
+		expect(first.added).toBe(true);
+		expect(second.added).toBe(false);
+		expect(second.item.id).toBe(first.item.id);
+		expect(loadMemoryNamespaces(root, ["health/paipai"]).map((item) => item.id)).toEqual([first.item.id]);
 	});
 
-	it("does not retrieve from transport metadata alone", () => {
-		expect(retrieveStructuredMemory(fixture(), "[DM from +8617612150403] 继续？")).toEqual([]);
+	it("allows unknown factual dates without inventing one", async () => {
+		const result = await saveMemory(fixture(), {
+			text: "Henry prefers concise replies",
+			namespace: "preference/henry",
+			kind: "preference",
+			subjects: ["Henry"],
+			event_time: null,
+			source: "legacy memory migration",
+			importance: 0.7,
+			confidence: 1,
+		});
+		expect(result.item.event_time).toBeNull();
 	});
 });

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -13,8 +13,8 @@
 
 import { existsSync, mkdirSync, readFileSync, unlinkSync } from "node:fs";
 import { join } from "node:path";
-import type { AssistantMessage, Message, TextContent } from "@mariozechner/pi-ai";
-import type { CompactionResult } from "@mariozechner/pi-coding-agent";
+import { type AssistantMessage, type Message, type TextContent, Type } from "@mariozechner/pi-ai";
+import type { CompactionResult, ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import {
 	type AgentSession,
 	AuthStorage,
@@ -23,9 +23,10 @@ import {
 	SessionManager,
 	SettingsManager,
 	createAgentSession,
+	defineTool,
 	getAgentDir,
 } from "@mariozechner/pi-coding-agent";
-import { formatStructuredMemory, readCoreMemory, retrieveStructuredMemory } from "./memory.js";
+import { listMemoryNamespaces, loadMemoryNamespaces, readCoreMemory, saveMemory, searchMemory } from "./memory.js";
 import type { AgentReply, IncomingMessage } from "./types.js";
 
 // ── Config & Types ────────────────────────────────────────────────────────────
@@ -100,6 +101,9 @@ function getCustomPrompt(workingDir: string, chatDir?: string): string {
 
 function buildSystemPrompt(workingDir: string, chatDir?: string): string {
 	const coreMemory = readCoreMemory(workingDir);
+	const namespaces = listMemoryNamespaces(workingDir)
+		.map((item) => `${item.namespace} (${item.active} active)`)
+		.join(", ");
 	const customPrompt = getCustomPrompt(workingDir, chatDir);
 
 	return `You are the user's best friend communicating via iMessage. Be concise. No emojis.
@@ -131,18 +135,17 @@ ${workingDir}/
 Structured memory is the only active read/write memory. Legacy MEMORY.md files are read-only archives.
 
 Read:
-- Relevant active records are automatically attached to each user message.
-- If automatic retrieval is insufficient, run:
-  python3 ${workingDir}/skills/file-memory/memory_cli.py search "query" --subject <name> --category <category>
+- Use the typed load_memory tool when prior context may help. You choose one or more relevant namespaces from meaning and conversation context, not fixed keywords.
+- load_memory returns every active record in each selected namespace. A namespace is injected only once per session; later calls return only newly added records.
+- Available namespaces: ${namespaces || "(none yet)"}
+- Use search_memory only to find a specific old record, especially before a correction. Do not use it as automatic per-record retrieval.
 - Treat retrieved memory as context, not as a substitute for the current message or verified facts.
 
 Write:
-- When you learn something important and durable, use memory_cli.py add; do not edit MEMORY.md directly.
-- Required fields: concise atomic text, category, subjects, event date, and specific source.
-- Example:
-  python3 ${workingDir}/skills/file-memory/memory_cli.py add --text "fact" --category preference --subjects Henry --event-time YYYY-MM-DD --source "private chat message"
+- When you learn something important and durable, call save_memory with concise atomic text, namespace, kind, subjects, factual event date when known, and a specific source.
 - Do not store every message, guesses, short-lived states, secrets, or duplicate facts.
-- For corrections, search for the old ID and add the corrected record with --supersedes <old-id>. Never silently overwrite history.
+- For corrections, find the old ID and set supersedes_id. Never silently overwrite history.
+- Do not edit JSONL or legacy MEMORY.md directly.
 
 ### Core Memory
 ${coreMemory}
@@ -236,9 +239,99 @@ function extractToolResultText(result: unknown): string {
 /** Pick a human-readable label for a tool invocation. */
 function extractToolLabel(toolName: string, args: Record<string, unknown>): string {
 	if (toolName === "bash" && typeof args.command === "string") return args.command;
+	if (toolName === "load_memory" && Array.isArray(args.namespaces)) return `memory: ${args.namespaces.join(", ")}`;
 	if (typeof args.path === "string") return `${toolName}: ${args.path}`;
 	if (typeof args.label === "string") return args.label;
 	return toolName;
+}
+
+function createMemoryExtension(workingDir: string, loadedIds: Set<string>) {
+	return (pi: ExtensionAPI): void => {
+		pi.registerTool(
+			defineTool({
+				name: "load_memory",
+				label: "Load Memory",
+				description:
+					"Load all active records from one or more semantically relevant namespaces. Select namespaces yourself from the conversation. Repeated calls return only records not already loaded in this session.",
+				parameters: Type.Object({
+					namespaces: Type.Array(Type.String(), { minItems: 1 }),
+				}),
+				async execute(_toolCallId, params) {
+					const records = loadMemoryNamespaces(workingDir, params.namespaces);
+					const delta = records.filter((item) => !loadedIds.has(item.id));
+					for (const item of delta) loadedIds.add(item.id);
+					return {
+						content: [
+							{
+								type: "text",
+								text: JSON.stringify({
+									namespaces: params.namespaces,
+									records: delta,
+									already_loaded: records.length - delta.length,
+								}),
+							},
+						],
+						details: { namespaces: params.namespaces, loaded: delta.length },
+					};
+				},
+			})
+		);
+
+		pi.registerTool(
+			defineTool({
+				name: "search_memory",
+				label: "Search Memory",
+				description: "Find a specific active memory record, primarily to locate its ID before saving a correction.",
+				parameters: Type.Object({
+					query: Type.String(),
+					namespaces: Type.Optional(Type.Array(Type.String())),
+					limit: Type.Optional(Type.Number({ minimum: 1, maximum: 50 })),
+				}),
+				async execute(_toolCallId, params) {
+					const records = searchMemory(workingDir, params.query, {
+						namespaces: params.namespaces,
+						limit: params.limit,
+					});
+					return {
+						content: [{ type: "text", text: JSON.stringify({ records }) }],
+						details: { matches: records.length },
+					};
+				},
+			})
+		);
+
+		pi.registerTool(
+			defineTool({
+				name: "save_memory",
+				label: "Save Memory",
+				description: "Validate and append one durable atomic record to the structured memory source of truth.",
+				parameters: Type.Object({
+					text: Type.String(),
+					namespace: Type.String(),
+					kind: Type.Union([
+						Type.Literal("fact"),
+						Type.Literal("event"),
+						Type.Literal("preference"),
+						Type.Literal("procedure"),
+					]),
+					subjects: Type.Array(Type.String()),
+					event_time: Type.Union([Type.String(), Type.Null()]),
+					source: Type.String(),
+					importance: Type.Number({ minimum: 0, maximum: 1 }),
+					confidence: Type.Number({ minimum: 0, maximum: 1 }),
+					supersedes_id: Type.Optional(Type.String()),
+				}),
+				async execute(_toolCallId, params) {
+					const result = await saveMemory(workingDir, params);
+					loadedIds.add(result.item.id);
+					return {
+						content: [{ type: "text", text: JSON.stringify(result) }],
+						details: { added: result.added, id: result.item.id },
+					};
+				},
+			})
+		);
+	};
 }
 
 // ── Agent Manager ─────────────────────────────────────────────────────────────
@@ -255,6 +348,7 @@ export async function createAgentManager(config: AgentManagerConfig) {
 		const chatDir = join(workingDir, sanitizeChatGuid(chatGuid));
 		mkdirSync(chatDir, { recursive: true });
 		const sessionManager = SessionManager.open(join(chatDir, "context.jsonl"), chatDir);
+		const loadedMemoryIds = new Set<string>();
 
 		// Per-chat resource loader so the system prompt can reference chatDir.
 		const resourceLoader = new DefaultResourceLoader({
@@ -262,6 +356,7 @@ export async function createAgentManager(config: AgentManagerConfig) {
 			agentDir,
 			systemPrompt: buildSystemPrompt(workingDir, chatDir),
 			noExtensions: true,
+			extensionFactories: [createMemoryExtension(workingDir, loadedMemoryIds)],
 			noSkills: true,
 			noPromptTemplates: true,
 			noThemes: true,
@@ -311,9 +406,7 @@ export async function createAgentManager(config: AgentManagerConfig) {
 	): Promise<void> {
 		const { session, chatGuid } = entry;
 
-		const basePromptText = formatPromptText(msg);
-		const relevantMemory = formatStructuredMemory(retrieveStructuredMemory(workingDir, basePromptText));
-		const promptText = relevantMemory ? `${relevantMemory}\n\n${basePromptText}` : basePromptText;
+		const promptText = formatPromptText(msg);
 
 		const images = msg.images.length > 0 ? msg.images : undefined;
 		const modelLabel = session.model ? `${session.model.provider}/${session.model.id}` : "default";
@@ -321,8 +414,7 @@ export async function createAgentManager(config: AgentManagerConfig) {
 		const queueWaitMs = promptStart - queuedAt;
 		console.log(
 			`[agent] prompt start: ${chatGuid} model=${modelLabel} queue_ms=${queueWaitMs} ` +
-				`chars=${basePromptText.length} memory_items=${relevantMemory ? relevantMemory.split("\n").length - 1 : 0} ` +
-				`images=${msg.images.length} "${basePromptText.substring(0, 60)}"`
+				`chars=${promptText.length} images=${msg.images.length} "${promptText.substring(0, 60)}"`
 		);
 
 		// Subscribe for this prompt's lifetime, routing events through handler
@@ -351,7 +443,9 @@ export async function createAgentManager(config: AgentManagerConfig) {
 			} else if (event.type === "tool_execution_start") {
 				const toolArgs = event.args as Record<string, unknown>;
 				const label = extractToolLabel(event.toolName, toolArgs);
-				const hidden = event.toolName === "bash" && label.includes("skills/file-memory/memory_cli.py");
+				const hidden =
+					["load_memory", "search_memory", "save_memory"].includes(event.toolName) ||
+					(event.toolName === "bash" && label.includes("skills/file-memory/memory_cli.py"));
 				pendingTools.set(event.toolCallId, { toolName: event.toolName, startTime: Date.now(), hidden });
 				console.log(`[agent] tool start: ${chatGuid} → ${label}`);
 				if (!hidden) replyChain = replyChain.then(() => handler({ kind: "tool_start", label }));

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -25,6 +25,7 @@ import {
 	createAgentSession,
 	getAgentDir,
 } from "@mariozechner/pi-coding-agent";
+import { formatStructuredMemory, readCoreMemory, retrieveStructuredMemory } from "./memory.js";
 import type { AgentReply, IncomingMessage } from "./types.js";
 
 // ── Config & Types ────────────────────────────────────────────────────────────
@@ -86,18 +87,6 @@ function readFileIfExists(path: string): string | undefined {
 	}
 }
 
-/** Read global and chat-specific MEMORY.md files, returning combined content. */
-function getMemory(workingDir: string, chatDir?: string): string {
-	const parts: string[] = [];
-	const global = readFileIfExists(join(workingDir, "MEMORY.md"));
-	if (global) parts.push(`### Global Memory\n${global}`);
-	if (chatDir) {
-		const chat = readFileIfExists(join(chatDir, "MEMORY.md"));
-		if (chat) parts.push(`### Chat Memory\n${chat}`);
-	}
-	return parts.length > 0 ? parts.join("\n\n") : "(no memory yet)";
-}
-
 function getCustomPrompt(workingDir: string, chatDir?: string): string {
 	const parts: string[] = [];
 	const global = readFileIfExists(join(workingDir, "SYSTEM.md"));
@@ -110,7 +99,7 @@ function getCustomPrompt(workingDir: string, chatDir?: string): string {
 }
 
 function buildSystemPrompt(workingDir: string, chatDir?: string): string {
-	const memory = getMemory(workingDir, chatDir);
+	const coreMemory = readCoreMemory(workingDir);
 	const customPrompt = getCustomPrompt(workingDir, chatDir);
 
 	return `You are the user's best friend communicating via iMessage. Be concise. No emojis.
@@ -127,11 +116,11 @@ You are running directly on the host machine.
 ## Workspace Layout
 ${workingDir}/
 ├── settings.json                # Bot configuration (see below)
-├── MEMORY.md                    # Global memory (all chats)
+├── MEMORY.md                    # Legacy memory archive; do not write new entries
 ├── SYSTEM.md                    # System configuration log
-├── skills/                      # Global CLI tools you create
+├── skills/file-memory/          # Structured memory store and CLI
 └── <chatId>/                    # Each iMessage chat gets a directory
-    ├── MEMORY.md                # Chat-specific memory
+    ├── MEMORY.md                # Legacy chat memory archive
     ├── context.jsonl            # LLM context (session persistence)
     ├── log.jsonl                # Message history
     ├── attachments/             # User-shared files
@@ -139,18 +128,24 @@ ${workingDir}/
     └── skills/                  # Chat-specific tools
 
 ## Memory
-Write to MEMORY.md files to persist context across conversations.
-- Global (${workingDir}/MEMORY.md): preferences, project info, shared knowledge
-- Chat-specific (<chatDir>/MEMORY.md): user details, ongoing topics, decisions
+Structured memory is the only active read/write memory. Legacy MEMORY.md files are read-only archives.
 
-Rules:
-- ALWAYS prefix entries with [YYYY-MM-DD]
-- ALWAYS note the source (chat message, URL, file path, etc.)
-- When updating conflicting info, keep the old entry with ~~strikethrough~~ and add the new one
-- Update MEMORY.md when you learn something important. No need to update after every message.
+Read:
+- Relevant active records are automatically attached to each user message.
+- If automatic retrieval is insufficient, run:
+  python3 ${workingDir}/skills/file-memory/memory_cli.py search "query" --subject <name> --category <category>
+- Treat retrieved memory as context, not as a substitute for the current message or verified facts.
 
-### Current Memory
-${memory}
+Write:
+- When you learn something important and durable, use memory_cli.py add; do not edit MEMORY.md directly.
+- Required fields: concise atomic text, category, subjects, event date, and specific source.
+- Example:
+  python3 ${workingDir}/skills/file-memory/memory_cli.py add --text "fact" --category preference --subjects Henry --event-time YYYY-MM-DD --source "private chat message"
+- Do not store every message, guesses, short-lived states, secrets, or duplicate facts.
+- For corrections, search for the old ID and add the corrected record with --supersedes <old-id>. Never silently overwrite history.
+
+### Core Memory
+${coreMemory}
 
 ## System Configuration Log
 Maintain ${workingDir}/SYSTEM.md to log all environment modifications:
@@ -316,7 +311,9 @@ export async function createAgentManager(config: AgentManagerConfig) {
 	): Promise<void> {
 		const { session, chatGuid } = entry;
 
-		const promptText = formatPromptText(msg);
+		const basePromptText = formatPromptText(msg);
+		const relevantMemory = formatStructuredMemory(retrieveStructuredMemory(workingDir, basePromptText));
+		const promptText = relevantMemory ? `${relevantMemory}\n\n${basePromptText}` : basePromptText;
 
 		const images = msg.images.length > 0 ? msg.images : undefined;
 		const modelLabel = session.model ? `${session.model.provider}/${session.model.id}` : "default";
@@ -324,14 +321,15 @@ export async function createAgentManager(config: AgentManagerConfig) {
 		const queueWaitMs = promptStart - queuedAt;
 		console.log(
 			`[agent] prompt start: ${chatGuid} model=${modelLabel} queue_ms=${queueWaitMs} ` +
-				`chars=${promptText.length} images=${msg.images.length} "${promptText.substring(0, 60)}"`
+				`chars=${basePromptText.length} memory_items=${relevantMemory ? relevantMemory.split("\n").length - 1 : 0} ` +
+				`images=${msg.images.length} "${basePromptText.substring(0, 60)}"`
 		);
 
 		// Subscribe for this prompt's lifetime, routing events through handler
 		let replyChain = Promise.resolve();
 		let firstAssistantStartMs: number | null = null;
 		let assistantDurationMs: number | null = null;
-		const pendingTools = new Map<string, { toolName: string; startTime: number }>();
+		const pendingTools = new Map<string, { toolName: string; startTime: number; hidden: boolean }>();
 
 		const unsubscribe = session.subscribe((event) => {
 			if (event.type === "message_start" && event.message.role === "assistant") {
@@ -353,9 +351,10 @@ export async function createAgentManager(config: AgentManagerConfig) {
 			} else if (event.type === "tool_execution_start") {
 				const toolArgs = event.args as Record<string, unknown>;
 				const label = extractToolLabel(event.toolName, toolArgs);
-				pendingTools.set(event.toolCallId, { toolName: event.toolName, startTime: Date.now() });
+				const hidden = event.toolName === "bash" && label.includes("skills/file-memory/memory_cli.py");
+				pendingTools.set(event.toolCallId, { toolName: event.toolName, startTime: Date.now(), hidden });
 				console.log(`[agent] tool start: ${chatGuid} → ${label}`);
-				replyChain = replyChain.then(() => handler({ kind: "tool_start", label }));
+				if (!hidden) replyChain = replyChain.then(() => handler({ kind: "tool_start", label }));
 			} else if (event.type === "tool_execution_end") {
 				const resultText = extractToolResultText(event.result);
 				const pending = pendingTools.get(event.toolCallId);
@@ -366,9 +365,11 @@ export async function createAgentManager(config: AgentManagerConfig) {
 					`[agent] tool end: ${chatGuid} ${symbol} ${event.toolName} (${duration}s)` +
 						` result="${resultText.substring(0, 60)}"`
 				);
-				replyChain = replyChain.then(() =>
-					handler({ kind: "tool_end", toolName: event.toolName, symbol, duration, result: resultText })
-				);
+				if (!pending?.hidden) {
+					replyChain = replyChain.then(() =>
+						handler({ kind: "tool_end", toolName: event.toolName, symbol, duration, result: resultText })
+					);
+				}
 			}
 		});
 

--- a/src/memory.ts
+++ b/src/memory.ts
@@ -1,54 +1,91 @@
-import { existsSync, readFileSync } from "node:fs";
-import { join } from "node:path";
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { appendFile, mkdir, rmdir } from "node:fs/promises";
+import { dirname, join, relative, sep } from "node:path";
+
+export const MEMORY_KINDS = ["fact", "event", "preference", "procedure"] as const;
+export type MemoryKind = (typeof MEMORY_KINDS)[number];
+
+export interface MemorySource {
+	type: string;
+	label: string;
+	path?: string;
+	line_start?: number;
+	line_end?: number;
+	block_hash?: string;
+}
 
 export interface StructuredMemoryItem {
 	id: string;
 	text: string;
-	category: string;
+	namespace: string;
+	kind: MemoryKind;
 	subjects: string[];
-	event_time: string;
+	event_time: string | null;
+	sources: MemorySource[];
 	importance: number;
 	confidence: number;
 	status: "active" | "superseded";
+	created_at: string;
 	supersedes_id?: string;
 }
 
-const CATEGORIES = ["person", "preference", "event", "health", "work_project", "procedure"] as const;
-const SUBJECT_ALIASES: Record<string, string[]> = {
-	Henry: ["henry", "大牙", "朱昌健"],
-	CC: ["cc"],
-	派派: ["派派", "小乖", "帅萌", "小帅萌"],
-};
-const CATEGORY_TERMS: Record<string, string[]> = {
-	health: [
-		"生病",
-		"发烧",
-		"退烧",
-		"体温",
-		"咳嗽",
-		"鼻涕",
-		"感染",
-		"病毒",
-		"肺炎",
-		"住院",
-		"出院",
-		"医生",
-		"药",
-		"检查",
-		"报告",
-		"血常规",
-		"crp",
-		"saa",
-	],
-	work_project: ["工作", "公司", "项目", "optiver", "github", "pi-imessage", "homelab", "sre"],
-	preference: ["喜欢", "不喜欢", "偏好", "希望"],
-	procedure: ["应该怎么", "规则", "原则", "必须", "以后", "排查", "流程"],
-	person: ["是谁", "姓名", "出生", "现居", "家庭", "妻子", "儿子"],
-	event: ["发生", "当时", "最近", "上次", "什么时候"],
-};
+export interface SaveMemoryInput {
+	text: string;
+	namespace: string;
+	kind: MemoryKind;
+	subjects: string[];
+	event_time: string | null;
+	source: string;
+	importance: number;
+	confidence: number;
+	supersedes_id?: string;
+}
+
+const NAMESPACE_PATTERN = /^[a-z0-9][a-z0-9-]*(?:\/[a-z0-9][a-z0-9-]*)+$/;
 
 function memoryRoot(workingDir: string): string {
 	return join(workingDir, "skills", "file-memory");
+}
+
+function namespaceRoot(workingDir: string): string {
+	return join(memoryRoot(workingDir), "namespaces");
+}
+
+function namespacePath(workingDir: string, namespace: string): string {
+	if (!NAMESPACE_PATTERN.test(namespace)) throw new Error(`Invalid memory namespace: ${namespace}`);
+	return `${join(namespaceRoot(workingDir), ...namespace.split("/"))}.jsonl`;
+}
+
+function findJsonlFiles(root: string): string[] {
+	if (!existsSync(root)) return [];
+	const result: string[] = [];
+	for (const entry of readdirSync(root, { withFileTypes: true })) {
+		const path = join(root, entry.name);
+		if (entry.isDirectory()) result.push(...findJsonlFiles(path));
+		else if (entry.isFile() && entry.name.endsWith(".jsonl")) result.push(path);
+	}
+	return result.sort();
+}
+
+function namespaceFromPath(workingDir: string, path: string): string {
+	return relative(namespaceRoot(workingDir), path)
+		.replaceAll(sep, "/")
+		.replace(/\.jsonl$/, "");
+}
+
+function parseJsonl(path: string): StructuredMemoryItem[] {
+	if (!existsSync(path)) return [];
+	const items: StructuredMemoryItem[] = [];
+	for (const [index, raw] of readFileSync(path, "utf8").split("\n").entries()) {
+		if (!raw.trim()) continue;
+		try {
+			items.push(JSON.parse(raw) as StructuredMemoryItem);
+		} catch (error) {
+			throw new Error(`Invalid memory JSONL ${path}:${index + 1}: ${error}`);
+		}
+	}
+	return items;
 }
 
 export function readCoreMemory(workingDir: string): string {
@@ -62,111 +99,149 @@ export function readCoreMemory(workingDir: string): string {
 	}
 }
 
-export function loadStructuredMemories(workingDir: string): StructuredMemoryItem[] {
-	const items: StructuredMemoryItem[] = [];
-	for (const category of CATEGORIES) {
-		const path = join(memoryRoot(workingDir), "categories", `${category}.jsonl`);
-		if (!existsSync(path)) continue;
-		try {
-			for (const [index, raw] of readFileSync(path, "utf8").split("\n").entries()) {
-				if (!raw.trim()) continue;
-				try {
-					items.push(JSON.parse(raw) as StructuredMemoryItem);
-				} catch (error) {
-					console.warn(`[memory] invalid JSONL ${path}:${index + 1}: ${error}`);
-				}
-			}
-		} catch (error) {
-			console.warn(`[memory] failed to read ${path}: ${error}`);
-		}
-	}
-	return items;
+export function listMemoryNamespaces(workingDir: string): Array<{ namespace: string; total: number; active: number }> {
+	return findJsonlFiles(namespaceRoot(workingDir)).map((path) => {
+		const items = parseJsonl(path);
+		return {
+			namespace: namespaceFromPath(workingDir, path),
+			total: items.length,
+			active: activeMemoryItems(items).length,
+		};
+	});
 }
 
-function activeMemories(items: StructuredMemoryItem[]): StructuredMemoryItem[] {
+export function loadAllMemoryItems(workingDir: string): StructuredMemoryItem[] {
+	return findJsonlFiles(namespaceRoot(workingDir)).flatMap(parseJsonl);
+}
+
+export function activeMemoryItems(items: StructuredMemoryItem[]): StructuredMemoryItem[] {
 	const supersededIds = new Set(
 		items.filter((item) => item.status === "active" && item.supersedes_id).map((item) => item.supersedes_id as string)
 	);
 	return items.filter((item) => item.status === "active" && !supersededIds.has(item.id));
 }
 
-function matchedSubjects(query: string): string[] {
-	const low = query.toLowerCase();
-	const result: string[] = [];
-	for (const [subject, aliases] of Object.entries(SUBJECT_ALIASES)) {
-		if (aliases.some((alias) => low.includes(alias))) result.push(subject);
-	}
-	if (result.length === 0 && /(^|[\s])我(的|们|感觉|觉得|想|不|要|是|有|在|会|能|就|也|还|最近|今天)/.test(query)) {
-		if (query.includes("from +8617612150403")) result.push("Henry");
-		if (query.includes("from +8618930176019")) result.push("CC");
-	}
-	return result;
+export function loadMemoryNamespaces(workingDir: string, namespaces: string[]): StructuredMemoryItem[] {
+	const selected = new Set(namespaces);
+	for (const namespace of selected) namespacePath(workingDir, namespace);
+	return activeMemoryItems(loadAllMemoryItems(workingDir)).filter((item) => selected.has(item.namespace));
 }
 
-function matchedCategories(query: string): string[] {
-	const low = query.toLowerCase();
-	return Object.entries(CATEGORY_TERMS)
-		.filter(([, terms]) => terms.some((term) => low.includes(term)))
-		.map(([category]) => category);
+export function searchMemory(
+	workingDir: string,
+	query: string,
+	options: { namespaces?: string[]; limit?: number } = {}
+): StructuredMemoryItem[] {
+	const terms = query
+		.toLowerCase()
+		.split(/[\s,，、]+/)
+		.filter(Boolean);
+	const selected = options.namespaces ? new Set(options.namespaces) : undefined;
+	const matches = activeMemoryItems(loadAllMemoryItems(workingDir))
+		.filter((item) => !selected || selected.has(item.namespace))
+		.map((item) => {
+			const haystack = [item.text, item.namespace, item.kind, ...item.subjects].join(" ").toLowerCase();
+			const lexical = terms.filter((term) => haystack.includes(term)).length;
+			return { item, lexical };
+		})
+		.filter(({ lexical }) => terms.length === 0 || lexical > 0)
+		.sort(
+			(a, b) =>
+				b.lexical - a.lexical ||
+				b.item.importance - a.item.importance ||
+				(b.item.event_time ?? "").localeCompare(a.item.event_time ?? "")
+		);
+	return matches.slice(0, options.limit ?? 10).map(({ item }) => item);
 }
 
-function queryTerms(query: string): string[] {
-	const low = query.toLowerCase();
-	const knownTerms = [
-		...new Set(
-			Object.values(CATEGORY_TERMS)
-				.flat()
-				.filter((term) => low.includes(term))
-		),
-	];
-	const latinTerms = low.match(/[a-z0-9][a-z0-9_.-]{1,}/g) ?? [];
-	const chineseStopBigrams = new Set(["我们", "他们", "什么", "怎么", "现在", "最近", "时候", "上次", "今天"]);
-	const chineseBigrams: string[] = [];
-	for (const sequence of low.match(/[\p{Script=Han}]{3,}/gu) ?? []) {
-		for (let index = 0; index < sequence.length - 1; index += 1) {
-			const bigram = sequence.slice(index, index + 2);
-			if (!chineseStopBigrams.has(bigram)) chineseBigrams.push(bigram);
+function validateSaveInput(input: SaveMemoryInput): void {
+	if (!input.text.trim()) throw new Error("Memory text must not be empty");
+	if (!NAMESPACE_PATTERN.test(input.namespace)) throw new Error(`Invalid memory namespace: ${input.namespace}`);
+	if (!MEMORY_KINDS.includes(input.kind)) throw new Error(`Invalid memory kind: ${input.kind}`);
+	if (input.event_time !== null && !/^\d{4}-\d{2}-\d{2}$/.test(input.event_time)) {
+		throw new Error("event_time must be YYYY-MM-DD or null");
+	}
+	if (!input.source.trim()) throw new Error("Memory source must not be empty");
+	if (input.importance < 0 || input.importance > 1 || input.confidence < 0 || input.confidence > 1) {
+		throw new Error("importance and confidence must be between 0 and 1");
+	}
+}
+
+function stableKey(input: Omit<SaveMemoryInput, "source" | "importance" | "confidence">): string {
+	return JSON.stringify({
+		text: input.text.trim().replace(/\s+/g, " "),
+		namespace: input.namespace,
+		kind: input.kind,
+		subjects: [...new Set(input.subjects.map((subject) => subject.trim()).filter(Boolean))].sort(),
+		event_time: input.event_time,
+		supersedes_id: input.supersedes_id,
+	});
+}
+
+async function withWriteLock<T>(workingDir: string, operation: () => Promise<T>): Promise<T> {
+	const lockPath = join(memoryRoot(workingDir), ".write-lock");
+	const deadline = Date.now() + 5_000;
+	while (true) {
+		try {
+			await mkdir(lockPath);
+			break;
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+			if (Date.now() >= deadline) throw new Error("Timed out waiting for memory write lock");
+			await new Promise((resolve) => setTimeout(resolve, 50));
 		}
 	}
-	return [...new Set([...knownTerms, ...latinTerms, ...chineseBigrams])];
-}
-
-export function retrieveStructuredMemory(workingDir: string, query: string, limit = 8): StructuredMemoryItem[] {
-	const content = query.replace(/^\[(?:DM|SMS|Group)[^\]]*\]\s*/i, "").replace(/^\[replying to:[^\]]*\]\s*/i, "");
-	const subjects = matchedSubjects(content).length > 0 ? matchedSubjects(content) : matchedSubjects(query);
-	const categories = matchedCategories(content);
-	const terms = queryTerms(content);
-	if (subjects.length === 0 && categories.length === 0 && terms.length === 0) return [];
-
-	const now = Date.now();
-	const scored: Array<{ item: StructuredMemoryItem; score: number }> = [];
-	const seenText = new Set<string>();
-	for (const item of activeMemories(loadStructuredMemories(workingDir))) {
-		if (subjects.length > 0 && !subjects.some((subject) => item.subjects.includes(subject))) continue;
-		const normalizedText = item.text.replace(/\s+/g, "").toLowerCase();
-		if (seenText.has(normalizedText)) continue;
-		const categoryMatch = categories.includes(item.category) ? 1 : 0;
-		const lexical = terms.filter((term) => normalizedText.includes(term)).length;
-		const subjectMatch = subjects.filter((subject) => item.subjects.includes(subject)).length;
-		if (categoryMatch === 0 && lexical === 0 && subjectMatch === 0) continue;
-		const timestamp = Date.parse(`${item.event_time}T00:00:00Z`);
-		const ageDays = Number.isFinite(timestamp) ? Math.max(0, (now - timestamp) / 86_400_000) : 365;
-		const recency = 1 / (1 + ageDays / 30);
-		const score = lexical * 3 + subjectMatch * 2 + categoryMatch * 2 + item.importance + item.confidence + recency;
-		scored.push({ item, score });
-		seenText.add(normalizedText);
+	try {
+		return await operation();
+	} finally {
+		await rmdir(lockPath).catch(() => {});
 	}
-	return scored
-		.sort((a, b) => b.score - a.score || b.item.event_time.localeCompare(a.item.event_time))
-		.slice(0, limit)
-		.map(({ item }) => item);
 }
 
-export function formatStructuredMemory(items: StructuredMemoryItem[]): string {
-	if (items.length === 0) return "";
-	const lines = items.map(
-		(item) =>
-			`- ${item.event_time} | ${item.category} | ${item.subjects.join(",") || "unspecified"} | ${item.id} | ${item.text}`
-	);
-	return `Relevant structured memory (retrieved automatically; active records only):\n${lines.join("\n")}`;
+export async function saveMemory(
+	workingDir: string,
+	input: SaveMemoryInput
+): Promise<{ added: boolean; item: StructuredMemoryItem }> {
+	validateSaveInput(input);
+	return withWriteLock(workingDir, async () => {
+		const existing = loadAllMemoryItems(workingDir);
+		const ids = new Set(existing.map((item) => item.id));
+		if (input.supersedes_id && !ids.has(input.supersedes_id)) {
+			throw new Error(`Unknown supersedes_id: ${input.supersedes_id}`);
+		}
+		const normalized = stableKey(input);
+		const id = `mem_${createHash("sha256").update(normalized).digest("hex").slice(0, 16)}`;
+		const duplicate = existing.find(
+			(item) =>
+				item.id === id ||
+				stableKey({
+					text: item.text,
+					namespace: item.namespace,
+					kind: item.kind,
+					subjects: item.subjects,
+					event_time: item.event_time,
+					supersedes_id: item.supersedes_id,
+				}) === normalized
+		);
+		if (duplicate) return { added: false, item: duplicate };
+
+		const item: StructuredMemoryItem = {
+			id,
+			text: input.text.trim(),
+			namespace: input.namespace,
+			kind: input.kind,
+			subjects: [...new Set(input.subjects.map((subject) => subject.trim()).filter(Boolean))].sort(),
+			event_time: input.event_time,
+			sources: [{ type: "chat", label: input.source.trim() }],
+			importance: input.importance,
+			confidence: input.confidence,
+			status: "active",
+			created_at: new Date().toISOString(),
+			...(input.supersedes_id ? { supersedes_id: input.supersedes_id } : {}),
+		};
+		const path = namespacePath(workingDir, input.namespace);
+		await mkdir(dirname(path), { recursive: true });
+		await appendFile(path, `${JSON.stringify(item)}\n`, "utf8");
+		return { added: true, item };
+	});
 }

--- a/src/memory.ts
+++ b/src/memory.ts
@@ -1,0 +1,172 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+export interface StructuredMemoryItem {
+	id: string;
+	text: string;
+	category: string;
+	subjects: string[];
+	event_time: string;
+	importance: number;
+	confidence: number;
+	status: "active" | "superseded";
+	supersedes_id?: string;
+}
+
+const CATEGORIES = ["person", "preference", "event", "health", "work_project", "procedure"] as const;
+const SUBJECT_ALIASES: Record<string, string[]> = {
+	Henry: ["henry", "大牙", "朱昌健"],
+	CC: ["cc"],
+	派派: ["派派", "小乖", "帅萌", "小帅萌"],
+};
+const CATEGORY_TERMS: Record<string, string[]> = {
+	health: [
+		"生病",
+		"发烧",
+		"退烧",
+		"体温",
+		"咳嗽",
+		"鼻涕",
+		"感染",
+		"病毒",
+		"肺炎",
+		"住院",
+		"出院",
+		"医生",
+		"药",
+		"检查",
+		"报告",
+		"血常规",
+		"crp",
+		"saa",
+	],
+	work_project: ["工作", "公司", "项目", "optiver", "github", "pi-imessage", "homelab", "sre"],
+	preference: ["喜欢", "不喜欢", "偏好", "希望"],
+	procedure: ["应该怎么", "规则", "原则", "必须", "以后", "排查", "流程"],
+	person: ["是谁", "姓名", "出生", "现居", "家庭", "妻子", "儿子"],
+	event: ["发生", "当时", "最近", "上次", "什么时候"],
+};
+
+function memoryRoot(workingDir: string): string {
+	return join(workingDir, "skills", "file-memory");
+}
+
+export function readCoreMemory(workingDir: string): string {
+	const path = join(memoryRoot(workingDir), "core.md");
+	if (!existsSync(path)) return "(no core memory yet)";
+	try {
+		return readFileSync(path, "utf8").trim() || "(no core memory yet)";
+	} catch (error) {
+		console.warn(`[memory] failed to read core memory: ${error}`);
+		return "(core memory unavailable)";
+	}
+}
+
+export function loadStructuredMemories(workingDir: string): StructuredMemoryItem[] {
+	const items: StructuredMemoryItem[] = [];
+	for (const category of CATEGORIES) {
+		const path = join(memoryRoot(workingDir), "categories", `${category}.jsonl`);
+		if (!existsSync(path)) continue;
+		try {
+			for (const [index, raw] of readFileSync(path, "utf8").split("\n").entries()) {
+				if (!raw.trim()) continue;
+				try {
+					items.push(JSON.parse(raw) as StructuredMemoryItem);
+				} catch (error) {
+					console.warn(`[memory] invalid JSONL ${path}:${index + 1}: ${error}`);
+				}
+			}
+		} catch (error) {
+			console.warn(`[memory] failed to read ${path}: ${error}`);
+		}
+	}
+	return items;
+}
+
+function activeMemories(items: StructuredMemoryItem[]): StructuredMemoryItem[] {
+	const supersededIds = new Set(
+		items.filter((item) => item.status === "active" && item.supersedes_id).map((item) => item.supersedes_id as string)
+	);
+	return items.filter((item) => item.status === "active" && !supersededIds.has(item.id));
+}
+
+function matchedSubjects(query: string): string[] {
+	const low = query.toLowerCase();
+	const result: string[] = [];
+	for (const [subject, aliases] of Object.entries(SUBJECT_ALIASES)) {
+		if (aliases.some((alias) => low.includes(alias))) result.push(subject);
+	}
+	if (result.length === 0 && /(^|[\s])我(的|们|感觉|觉得|想|不|要|是|有|在|会|能|就|也|还|最近|今天)/.test(query)) {
+		if (query.includes("from +8617612150403")) result.push("Henry");
+		if (query.includes("from +8618930176019")) result.push("CC");
+	}
+	return result;
+}
+
+function matchedCategories(query: string): string[] {
+	const low = query.toLowerCase();
+	return Object.entries(CATEGORY_TERMS)
+		.filter(([, terms]) => terms.some((term) => low.includes(term)))
+		.map(([category]) => category);
+}
+
+function queryTerms(query: string): string[] {
+	const low = query.toLowerCase();
+	const knownTerms = [
+		...new Set(
+			Object.values(CATEGORY_TERMS)
+				.flat()
+				.filter((term) => low.includes(term))
+		),
+	];
+	const latinTerms = low.match(/[a-z0-9][a-z0-9_.-]{1,}/g) ?? [];
+	const chineseStopBigrams = new Set(["我们", "他们", "什么", "怎么", "现在", "最近", "时候", "上次", "今天"]);
+	const chineseBigrams: string[] = [];
+	for (const sequence of low.match(/[\p{Script=Han}]{3,}/gu) ?? []) {
+		for (let index = 0; index < sequence.length - 1; index += 1) {
+			const bigram = sequence.slice(index, index + 2);
+			if (!chineseStopBigrams.has(bigram)) chineseBigrams.push(bigram);
+		}
+	}
+	return [...new Set([...knownTerms, ...latinTerms, ...chineseBigrams])];
+}
+
+export function retrieveStructuredMemory(workingDir: string, query: string, limit = 8): StructuredMemoryItem[] {
+	const content = query.replace(/^\[(?:DM|SMS|Group)[^\]]*\]\s*/i, "").replace(/^\[replying to:[^\]]*\]\s*/i, "");
+	const subjects = matchedSubjects(content).length > 0 ? matchedSubjects(content) : matchedSubjects(query);
+	const categories = matchedCategories(content);
+	const terms = queryTerms(content);
+	if (subjects.length === 0 && categories.length === 0 && terms.length === 0) return [];
+
+	const now = Date.now();
+	const scored: Array<{ item: StructuredMemoryItem; score: number }> = [];
+	const seenText = new Set<string>();
+	for (const item of activeMemories(loadStructuredMemories(workingDir))) {
+		if (subjects.length > 0 && !subjects.some((subject) => item.subjects.includes(subject))) continue;
+		const normalizedText = item.text.replace(/\s+/g, "").toLowerCase();
+		if (seenText.has(normalizedText)) continue;
+		const categoryMatch = categories.includes(item.category) ? 1 : 0;
+		const lexical = terms.filter((term) => normalizedText.includes(term)).length;
+		const subjectMatch = subjects.filter((subject) => item.subjects.includes(subject)).length;
+		if (categoryMatch === 0 && lexical === 0 && subjectMatch === 0) continue;
+		const timestamp = Date.parse(`${item.event_time}T00:00:00Z`);
+		const ageDays = Number.isFinite(timestamp) ? Math.max(0, (now - timestamp) / 86_400_000) : 365;
+		const recency = 1 / (1 + ageDays / 30);
+		const score = lexical * 3 + subjectMatch * 2 + categoryMatch * 2 + item.importance + item.confidence + recency;
+		scored.push({ item, score });
+		seenText.add(normalizedText);
+	}
+	return scored
+		.sort((a, b) => b.score - a.score || b.item.event_time.localeCompare(a.item.event_time))
+		.slice(0, limit)
+		.map(({ item }) => item);
+}
+
+export function formatStructuredMemory(items: StructuredMemoryItem[]): string {
+	if (items.length === 0) return "";
+	const lines = items.map(
+		(item) =>
+			`- ${item.event_time} | ${item.category} | ${item.subjects.join(",") || "unspecified"} | ${item.id} | ${item.text}`
+	);
+	return `Relevant structured memory (retrieved automatically; active records only):\n${lines.join("\n")}`;
+}


### PR DESCRIPTION
## Summary
- add typed `load_memory`, `search_memory`, and `save_memory` tools
- let the main LLM select complete two-level namespaces such as `health/paipai`
- load each memory record at most once per chat session
- support idempotent writes and superseding corrections
- keep legacy `MEMORY.md` files as read-only archives
- document one-time migration, runtime reads/writes, and nightly reflection

## Validation
- `npx biome check src/agent.ts src/memory.ts src/__tests__/memory.test.ts`
- `npm test` (36 tests)
- `npm run build`

## Design
- [Structured memory sequence flow](https://github.com/daya0576/pi-imessage/blob/feat/structured-file-memory/docs/structured-memory-sequence.md)