### PR TITLE
docs: add Cursor Cloud dev environment notes to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,3 +34,12 @@
 - When writing tests, run them, identify issues in either the test or implementation, and iterate until fixed.
 - NEVER commit unless user asks
 
+## Cursor Cloud specific instructions
+
+The Cloud VM is Linux; this is a **macOS-only** iMessage bot. Key implications for developing here:
+
+- The full bot cannot boot on Linux. `src/main.ts` calls `checkEnvironment()` (`src/send.ts`) unconditionally at startup, which requires a running `Messages.app` (`pgrep -x Messages`), read access to `~/Library/Messages/chat.db`, and `osascript`. So `npm start` / `npm run dev` will exit immediately here. The iMessage watcher (`src/watch.ts`) and sender (`src/send.ts`) are macOS-only and cannot be exercised in this environment.
+- What is fully runnable/verifiable on Linux: typecheck + lint via `npm run check`, and the test suite via `vitest` (70 tests pass). Note the repo command rules above say not to run `npm test` during normal coding; it is only run for environment verification.
+- The **structured memory** subsystem (`src/memory.ts`) and the web **Memory** tab (`src/web/render.ts` + `src/web/templates/memory.eta`) are platform-independent — no `chat.db`, `osascript`, or model/API keys required. They read/write JSONL under `WORKING_DIR/skills/file-memory/namespaces/`. To exercise the web Memory tab standalone without the macOS bot, seed a temp `WORKING_DIR` via `saveMemory()` and render with `renderMemoryPage()` (importing `src/agent.ts` pulls in `@earendil-works/pi-ai` at runtime, so avoid it if you only need the memory view).
+- A user's real pi-imessage **memory lives on their Mac** at `~/.pi/imessage/skills/file-memory/` (default `WORKING_DIR`). It is NOT present in a fresh Cloud VM; the VM only has whatever memory you seed locally.
+


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and verifies the development environment for `@kingcrab/pi-imessage` on the Cursor Cloud (Linux) VM, and documents the key non-obvious constraints for future agents.

This is a **macOS-only** iMessage bot: the full bot cannot boot on Linux because `src/main.ts` → `checkEnvironment()` requires `Messages.app`, `~/Library/Messages/chat.db`, and `osascript`. The runnable/verifiable surface on Linux is lint/typecheck, the test suite, and the platform-independent structured-memory subsystem + web Memory tab.

## Changes

- Added a `## Cursor Cloud specific instructions` section to `AGENTS.md` covering:
  - Why the bot can't start on Linux (macOS-only `checkEnvironment`, watcher, sender).
  - What is fully runnable here (`npm run check`, `vitest`).
  - That the memory subsystem + web Memory tab are platform-independent (no `chat.db`/API keys).
  - That a user's real pi-imessage memory lives on their Mac at `~/.pi/imessage/skills/file-memory/`, not in the Cloud VM.

No application code was modified.

## Verification

- `npm install` — dependencies installed (idempotent, used as update script).
- `npm run check` — `tsc --noEmit` + `biome check .` pass, 44 files.
- `vitest run` — 13 files, 70 tests pass.
- Demonstrated the memory feature end-to-end via the real `saveMemory()` / `searchMemory()` code and the real web Memory tab template, including a live write→read cycle.

[pi_imessage_memory_tab.mp4](https://cursor.com/agents/bc-78344758-7c47-4b5c-87f0-af47e6cb594a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpi_imessage_memory_tab.mp4)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-78344758-7c47-4b5c-87f0-af47e6cb594a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-78344758-7c47-4b5c-87f0-af47e6cb594a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

