### PR TITLE
fix(ops): make deployment rollback fail-safe and stabilize watchdog

### DIFF
--- a/ops/deploy-blue-green.sh
+++ b/ops/deploy-blue-green.sh
@@ -25,6 +25,8 @@ BOOTSTRAP="${BOOTSTRAP:-auto}"
 GREEN_PID=""
 NEW_RELEASE=""
 OLD_TARGET=""
+SWITCHED=false
+DEPLOY_SUCCEEDED=false
 
 log() {
   printf '[%s] %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$*"
@@ -40,11 +42,18 @@ send_progress() {
 }
 
 cleanup() {
+  local rc=$?
+  trap - EXIT
+  if [[ "${rc}" != "0" && "${SWITCHED}" == "true" && "${DEPLOY_SUCCEEDED}" != "true" ]]; then
+    log "Deployment failed after switch (exit=${rc}); forcing rollback"
+    rollback || log "Emergency rollback could not restore service"
+  fi
   if [[ -n "${GREEN_PID}" ]] && kill -0 "${GREEN_PID}" 2>/dev/null; then
     kill -TERM "${GREEN_PID}" 2>/dev/null || true
     wait "${GREEN_PID}" 2>/dev/null || true
   fi
   rmdir "${LOCK_DIR}" 2>/dev/null || true
+  exit "${rc}"
 }
 trap cleanup EXIT
 trap 'exit 130' INT TERM
@@ -79,14 +88,32 @@ atomic_link() {
   /bin/mv -fh "${temp}" "${link}"
 }
 
+start_active_service() {
+  local plist="${HOME}/Library/LaunchAgents/com.kingcrab.pi-imessage.plist"
+  if launchctl print "${SERVICE}" >/dev/null 2>&1; then
+    launchctl kickstart -k "${SERVICE}"
+    return
+  fi
+  [[ -f "${plist}" ]] || return 1
+  # launchctl can transiently return EIO immediately after a bootout. Retry
+  # bootstrap without first destroying any healthy loaded service.
+  for delay in 0 1 2 4; do
+    (( delay == 0 )) || sleep "${delay}"
+    launchctl bootstrap "gui/$(id -u)" "${plist}" >/dev/null 2>&1 && return 0
+  done
+  return 1
+}
+
 rollback() {
   [[ -n "${OLD_TARGET}" ]] || return 1
-  log "Post-switch health failed; rolling back to ${OLD_TARGET}"
+  log "Rolling back to ${OLD_TARGET}"
   atomic_link "${OLD_TARGET}" "${CURRENT_LINK}"
-  launchctl kickstart -k "${SERVICE}" >/dev/null 2>&1 || true
-  wait_http "${ACTIVE_URL}/health/runtime" "${START_TIMEOUT_SECONDS}" || true
-  check_model "${ACTIVE_URL}" || true
-  send_progress "pi-imessage 新版本健康检查失败，已自动回滚。"
+  start_active_service || true
+  if wait_http "${ACTIVE_URL}/health/runtime" "${START_TIMEOUT_SECONDS}"; then
+    send_progress "pi-imessage 新版本切换失败，旧版本已自动恢复。"
+    return 0
+  fi
+  return 1
 }
 
 if ! mkdir "${LOCK_DIR}" 2>/dev/null; then
@@ -190,21 +217,18 @@ fi
 if [[ -L "${CURRENT_LINK}" ]]; then OLD_TARGET="$(readlink "${CURRENT_LINK}")"; fi
 if [[ -n "${OLD_TARGET}" ]]; then atomic_link "${OLD_TARGET}" "${PREVIOUS_LINK}"; fi
 atomic_link "${NEW_RELEASE}" "${CURRENT_LINK}"
+SWITCHED=true
 
 log "Switching active service to ${NEW_RELEASE}"
-if [[ "${BOOTSTRAP}" == "auto" ]]; then
-  if launchctl print "${SERVICE}" 2>/dev/null | grep -q "${CURRENT_LINK}/dist/main.js"; then BOOTSTRAP=false; else BOOTSTRAP=true; fi
-fi
-if [[ "${BOOTSTRAP}" == "true" ]]; then
-  "${NEW_RELEASE}/ops/install-launchd.sh"
-else
-  launchctl kickstart -k "${SERVICE}"
-fi
+# Ordinary releases never bootout the live LaunchAgent. Its plist points at the
+# stable current symlink, so kickstart is sufficient. If it is unexpectedly
+# unloaded, bootstrap it with retries; any failure is caught by the EXIT trap.
+start_active_service
 if ! wait_http "${ACTIVE_URL}/health/runtime" "${START_TIMEOUT_SECONDS}" || ! check_model "${ACTIVE_URL}"; then
-  rollback
   exit 1
 fi
 
+DEPLOY_SUCCEEDED=true
 send_progress "pi-imessage 已完成蓝绿切换，切换后真实 LLM 健康检查通过。"
 log "Deployment succeeded"
 

--- a/ops/install-launchd.sh
+++ b/ops/install-launchd.sh
@@ -11,12 +11,17 @@ DOMAIN="gui/$(id -u)"
 LAUNCH_DIR="${HOME}/Library/LaunchAgents"
 SERVICE_PLIST="${LAUNCH_DIR}/${LABEL}.plist"
 WATCHDOG_PLIST="${LAUNCH_DIR}/${WATCHDOG_LABEL}.plist"
+STABLE_WATCHDOG="${IMESSAGE_DIR}/watchdog/pi-imessage-watchdog.sh"
 
 [[ -x "${CURRENT_LINK}/dist/main.js" || -f "${CURRENT_LINK}/dist/main.js" ]] || {
   echo "Missing built immutable release at ${CURRENT_LINK}" >&2
   exit 1
 }
 mkdir -p "${LAUNCH_DIR}" "${IMESSAGE_DIR}/logs" "${IMESSAGE_DIR}/watchdog"
+bash -n "${CURRENT_LINK}/ops/pi-imessage-watchdog.sh"
+cp "${CURRENT_LINK}/ops/pi-imessage-watchdog.sh" "${STABLE_WATCHDOG}.new"
+chmod 755 "${STABLE_WATCHDOG}.new"
+mv "${STABLE_WATCHDOG}.new" "${STABLE_WATCHDOG}"
 
 cat >"${SERVICE_PLIST}.new" <<PLIST
 <?xml version="1.0" encoding="UTF-8"?>
@@ -51,7 +56,7 @@ cat >"${WATCHDOG_PLIST}.new" <<PLIST
   <key>Label</key><string>${WATCHDOG_LABEL}</string>
   <key>ProgramArguments</key><array>
     <string>/bin/bash</string>
-    <string>${CURRENT_LINK}/ops/pi-imessage-watchdog.sh</string>
+    <string>${STABLE_WATCHDOG}</string>
   </array>
   <key>EnvironmentVariables</key><dict>
     <key>PATH</key><string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
@@ -65,10 +70,27 @@ PLIST
 plutil -lint "${WATCHDOG_PLIST}.new" >/dev/null
 mv "${WATCHDOG_PLIST}.new" "${WATCHDOG_PLIST}"
 
+bootstrap_with_retry() {
+  local plist="$1"
+  for delay in 0 1 2 4; do
+    (( delay == 0 )) || sleep "${delay}"
+    launchctl bootstrap "${DOMAIN}" "${plist}" >/dev/null 2>&1 && return 0
+  done
+  return 1
+}
+
+# Never unload a healthy main service during installation. The program path is
+# stable (`releases/current`), so a kickstart picks up the selected release.
+if launchctl print "${DOMAIN}/${LABEL}" >/dev/null 2>&1; then
+  launchctl kickstart -k "${DOMAIN}/${LABEL}"
+else
+  bootstrap_with_retry "${SERVICE_PLIST}"
+fi
+
+# The watchdog is independent of the app release. Reloading only this helper is
+# safe; even if it fails, the main service remains online.
 launchctl bootout "${DOMAIN}/${WATCHDOG_LABEL}" >/dev/null 2>&1 || true
-launchctl bootout "${DOMAIN}/${LABEL}" >/dev/null 2>&1 || true
-launchctl bootstrap "${DOMAIN}" "${SERVICE_PLIST}"
-launchctl bootstrap "${DOMAIN}" "${WATCHDOG_PLIST}"
+bootstrap_with_retry "${WATCHDOG_PLIST}"
 
 for _ in $(seq 1 60); do
   if curl -fsS --max-time 3 http://127.0.0.1:7750/health/runtime >/dev/null 2>&1; then break; fi

--- a/ops/pi-imessage-watchdog.sh
+++ b/ops/pi-imessage-watchdog.sh
@@ -32,11 +32,6 @@ fi
 
 launch_running() { launchctl print "${SERVICE}" 2>/dev/null | grep -q 'state = running'; }
 web_healthy() { curl -fsS --max-time 4 "${WEB_URL}/health/runtime" >/dev/null 2>&1; }
-messages_healthy() {
-  /usr/bin/osascript -e 'tell application "Messages" to return (count of accounts whose enabled is true)' \
-    2>/dev/null | grep -Eq '^[1-9][0-9]*$'
-}
-
 runtime_stuck() {
   local result active last now last_epoch
   result="$(curl -fsS --max-time 4 "${WEB_URL}/health/runtime" 2>/dev/null)" || return 1
@@ -59,7 +54,9 @@ restart_and_verify() {
   launchctl kickstart -k "${SERVICE}" >/dev/null 2>&1 || true
   for _ in $(seq 1 30); do
     sleep 1
-    launch_running && web_healthy && messages_healthy && return 0
+    # Only gate recovery on conditions restarting this worker can repair.
+    # Messages account availability is external and must not cause restart loops.
+    launch_running && web_healthy && return 0
   done
   return 1
 }
@@ -75,7 +72,7 @@ rollback() {
   restart_and_verify
 }
 
-if ! launch_running || ! web_healthy || ! messages_healthy || runtime_stuck; then
+if ! launch_running || ! web_healthy || runtime_stuck; then
   log "Local health failed; restarting active immutable release"
   if ! restart_and_verify; then
     log "Restart failed; attempting previous release"


### PR DESCRIPTION
## 范围
- 从线上修复 10e9c5c 独立提出。
- 正常发布不先 bootout 主服务；bootstrap 重试；symlink 切换后的失败通过 EXIT trap 回滚。
- watchdog 安装到 release-independent 稳定路径，移除不可靠的 Messages account 探针作为重启条件。
- 不包含自动远端审查、SDK 或业务功能。

## 验证与边界
- bash -n ops/*.sh
- git diff --check
- npm run check
- 这是已经在线使用的修复的审阅 PR；本次未再次运行部署/重启，也未新增实机故障注入测试。

仅供 diff 审阅，不自动合并或部署。
