### PR TITLE
feat(agent): isolate automated prompt sessions

### DIFF
--- a/src/__tests__/agent-session-isolation.test.ts
+++ b/src/__tests__/agent-session-isolation.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { resolveSessionStorage } from "../agent.js";
+
+describe("isolated agent session storage", () => {
+	it("keeps normal chat sessions in the chat directory", () => {
+		expect(resolveSessionStorage("/tmp/imessage", "iMessage;+;chat123")).toEqual({
+			mapKey: "iMessage;+;chat123",
+			sessionDir: "/tmp/imessage/iMessage;+;chat123",
+			isolated: false,
+		});
+	});
+
+	it("places task sessions outside the destination chat directory", () => {
+		expect(
+			resolveSessionStorage("/tmp/imessage", "iMessage;+;chat123", {
+				sessionKey: "night-sleep-2026-09-01",
+				ephemeral: true,
+			})
+		).toEqual({
+			mapKey: "task:iMessage;+;chat123:night-sleep-2026-09-01",
+			sessionDir: "/tmp/imessage/.task-sessions/iMessage;+;chat123/night-sleep-2026-09-01",
+			isolated: true,
+		});
+	});
+
+	it("scopes the same task key to its destination chat", () => {
+		const first = resolveSessionStorage("/tmp/imessage", "chat-a", { sessionKey: "daily-task" });
+		const second = resolveSessionStorage("/tmp/imessage", "chat-b", { sessionKey: "daily-task" });
+		expect(first.mapKey).not.toBe(second.mapKey);
+		expect(first.sessionDir).not.toBe(second.sessionDir);
+	});
+
+	it("rejects unsafe or incomplete ephemeral session options", () => {
+		expect(() => resolveSessionStorage("/tmp/imessage", "chat", { ephemeral: true })).toThrow(
+			"ephemeral sessions require sessionKey"
+		);
+		expect(() => resolveSessionStorage("/tmp/imessage", "chat", { sessionKey: "../escape" })).toThrow(
+			"sessionKey must be"
+		);
+	});
+});

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -11,7 +11,7 @@
  * Model: uses ~/.pi/agent/ defaults (via createAgentSession).
  */
 
-import { existsSync, mkdirSync, readFileSync, unlinkSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, rmSync, unlinkSync } from "node:fs";
 import { join } from "node:path";
 import { type AssistantMessage, type Message, type TextContent, Type } from "@earendil-works/pi-ai";
 import type { CompactionResult, ExtensionAPI } from "@earendil-works/pi-coding-agent";
@@ -85,8 +85,46 @@ export interface AgentManagerConfig {
 interface ChatSession {
 	session: AgentSession;
 	chatGuid: string;
-	/** Promise chain serializing prompts for this chat. */
+	sessionMapKey: string;
+	sessionDir: string;
+	/** Promise chain serializing prompts for this chat or isolated task session. */
 	chain: Promise<void>;
+}
+
+export interface ProcessMessageOptions {
+	streamingBehavior?: "steer" | "followUp";
+	/** Separate model context from the destination chat while still delivering replies there. */
+	sessionKey?: string;
+	/** Remove the isolated session after all prompts queued on it have completed. */
+	ephemeral?: boolean;
+}
+
+const SESSION_KEY_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9._-]{0,127}$/;
+
+export function resolveSessionStorage(
+	workingDir: string,
+	chatGuid: string,
+	options?: Pick<ProcessMessageOptions, "sessionKey" | "ephemeral">
+): { mapKey: string; sessionDir: string; isolated: boolean } {
+	if (options?.ephemeral && !options.sessionKey) {
+		throw new Error("ephemeral sessions require sessionKey");
+	}
+	if (!options?.sessionKey) {
+		return {
+			mapKey: chatGuid,
+			sessionDir: join(workingDir, sanitizeChatGuid(chatGuid)),
+			isolated: false,
+		};
+	}
+	if (!SESSION_KEY_PATTERN.test(options.sessionKey)) {
+		throw new Error("sessionKey must be 1-128 characters using only letters, numbers, '.', '_' or '-'");
+	}
+	const safeChatGuid = sanitizeChatGuid(chatGuid);
+	return {
+		mapKey: `task:${safeChatGuid}:${options.sessionKey}`,
+		sessionDir: join(workingDir, ".task-sessions", safeChatGuid, options.sessionKey),
+		isolated: true,
+	};
 }
 
 /**
@@ -343,7 +381,9 @@ curl -X POST http://localhost:7750/prompt \\
   -d '{"chatGuid":"<chatGuid>","prompt":"generate a daily summary"}'
 \`\`\`
 If the agent is already processing a message for this chat, the prompt is queued (followUp)
-and will run after the current processing finishes.
+and will run after the current processing finishes. Heavy automated tasks should provide a safe
+\`sessionKey\` and \`ephemeral:true\` so their tool and image context is isolated from the destination chat
+and removed after completion; replies are still delivered to \`chatGuid\`.
 
 ### POST /reminders — schedule a persistent one-time reminder
 Use this instead of creating a one-off script or crontab entry. \`scheduledAt\` must be
@@ -529,11 +569,10 @@ export async function createAgentManager(config: AgentManagerConfig) {
 		modelsPath: join(agentDir, "models.json"),
 	});
 
-	/** Create a new AgentSession for a chat, persisted to context.jsonl. */
-	async function createSession(chatGuid: string): Promise<ChatSession> {
-		const chatDir = join(workingDir, sanitizeChatGuid(chatGuid));
-		mkdirSync(chatDir, { recursive: true });
-		const sessionManager = SessionManager.open(join(chatDir, "context.jsonl"), chatDir);
+	/** Create a new AgentSession for a chat or isolated task, persisted to its own context.jsonl. */
+	async function createSession(sessionMapKey: string, chatGuid: string, sessionDir: string): Promise<ChatSession> {
+		mkdirSync(sessionDir, { recursive: true });
+		const sessionManager = SessionManager.open(join(sessionDir, "context.jsonl"), sessionDir);
 		const loadedMemoryIds = new Set<string>();
 
 		// Force SSE for pi-imessage. Large Codex contexts frequently exceed the
@@ -541,12 +580,12 @@ export async function createAgentManager(config: AgentManagerConfig) {
 		const settingsManager = SettingsManager.create(workingDir, agentDir);
 		settingsManager.applyOverrides({ transport: "sse" });
 
-		// Per-chat resource loader so the system prompt can reference chatDir.
+		// Per-session resource loader so the system prompt can reference its isolated directory.
 		const resourceLoader = new DefaultResourceLoader({
 			cwd: workingDir,
 			agentDir,
 			settingsManager,
-			systemPrompt: buildSystemPrompt(workingDir, sanitizeChatGuid(chatGuid), chatDir),
+			systemPrompt: buildSystemPrompt(workingDir, sanitizeChatGuid(chatGuid), sessionDir),
 			// Keep extension discovery disabled, but install this one controlled
 			// inline hook so Codex 5.6 fast mode still applies to iMessage.
 			extensionFactories: [
@@ -574,10 +613,12 @@ export async function createAgentManager(config: AgentManagerConfig) {
 		});
 
 		const modelLabel = session.model ? `${session.model.provider}/${session.model.id}` : "default";
-		console.log(`[agent] session created: ${chatGuid} model=${modelLabel} transport=sse sol_fast=priority`);
+		console.log(
+			`[agent] session created: ${chatGuid} session=${sessionMapKey} model=${modelLabel} transport=sse sol_fast=priority`
+		);
 
-		const entry: ChatSession = { session, chatGuid, chain: Promise.resolve() };
-		sessionMap.set(chatGuid, entry);
+		const entry: ChatSession = { session, chatGuid, sessionMapKey, sessionDir, chain: Promise.resolve() };
+		sessionMap.set(sessionMapKey, entry);
 		return entry;
 	}
 
@@ -590,13 +631,29 @@ export async function createAgentManager(config: AgentManagerConfig) {
 	async function processMessage(
 		msg: IncomingMessage,
 		handler: (reply: AgentReply) => Promise<void>,
-		options?: { streamingBehavior?: "steer" | "followUp" }
+		options?: ProcessMessageOptions
 	): Promise<void> {
-		const entry = sessionMap.get(msg.chatGuid) ?? (await createSession(msg.chatGuid));
+		const storage = resolveSessionStorage(workingDir, msg.chatGuid, options);
+		const entry =
+			sessionMap.get(storage.mapKey) ?? (await createSession(storage.mapKey, msg.chatGuid, storage.sessionDir));
 		const queuedAt = Date.now();
 		const run = () => runPrompt(entry, msg, handler, queuedAt, options);
-		entry.chain = entry.chain.then(run, run);
-		return entry.chain;
+		const runPromise = entry.chain.then(run, run);
+		entry.chain = runPromise;
+		try {
+			await runPromise;
+		} finally {
+			// Only the last prompt queued on an ephemeral session performs cleanup.
+			if (options?.ephemeral && entry.chain === runPromise && sessionMap.get(storage.mapKey) === entry) {
+				sessionMap.delete(storage.mapKey);
+				try {
+					rmSync(storage.sessionDir, { recursive: true, force: true });
+					console.log(`[agent] ephemeral session removed: ${storage.mapKey}`);
+				} catch (error) {
+					console.error(`[agent] ephemeral session cleanup failed: ${storage.mapKey}`, error);
+				}
+			}
+		}
 	}
 
 	async function runPrompt(
@@ -604,9 +661,9 @@ export async function createAgentManager(config: AgentManagerConfig) {
 		msg: IncomingMessage,
 		handler: (reply: AgentReply) => Promise<void>,
 		queuedAt: number,
-		options?: { streamingBehavior?: "steer" | "followUp" }
+		options?: ProcessMessageOptions
 	): Promise<void> {
-		const { session, chatGuid } = entry;
+		const { session, chatGuid, sessionMapKey } = entry;
 
 		const promptText = formatPromptText(msg);
 
@@ -694,7 +751,7 @@ export async function createAgentManager(config: AgentManagerConfig) {
 					console.error(
 						`[agent] prompt ${label}: ${chatGuid} after ${timeoutMs}ms — detaching session and aborting in background`
 					);
-					if (sessionMap.get(chatGuid) === entry) sessionMap.delete(chatGuid);
+					if (sessionMap.get(sessionMapKey) === entry) sessionMap.delete(sessionMapKey);
 					void clearAndAbortSession(session).catch((error) => {
 						console.error(`[agent] background abort failed: ${chatGuid}`, error);
 					});
@@ -716,7 +773,7 @@ export async function createAgentManager(config: AgentManagerConfig) {
 			// prompt only when the model-relative threshold has been crossed.
 			const contextUsage = session.getContextUsage();
 			const threshold = getAutoCompactTokenThreshold(session.model?.contextWindow);
-			if (typeof contextUsage?.tokens === "number" && contextUsage.tokens >= threshold) {
+			if (!options?.ephemeral && typeof contextUsage?.tokens === "number" && contextUsage.tokens >= threshold) {
 				console.log(
 					`[agent] post-reply compact start: ${chatGuid} tokens=${contextUsage.tokens} threshold=${threshold} ` +
 						`context_window=${session.model?.contextWindow ?? "unknown"}`
@@ -726,7 +783,7 @@ export async function createAgentManager(config: AgentManagerConfig) {
 						() => session.compact(),
 						() => {
 							console.error(`[agent] post-reply compact timeout: ${chatGuid} after ${AGENT_COMPACT_TIMEOUT_MS}ms`);
-							if (sessionMap.get(chatGuid) === entry) sessionMap.delete(chatGuid);
+							if (sessionMap.get(sessionMapKey) === entry) sessionMap.delete(sessionMapKey);
 							void clearAndAbortSession(session).catch(() => {});
 						},
 						AGENT_COMPACT_TIMEOUT_MS
@@ -762,7 +819,8 @@ export async function createAgentManager(config: AgentManagerConfig) {
 
 	/** Compact the session context, reducing token usage while preserving a summary. */
 	async function compact(chatGuid: string, customInstructions?: string): Promise<string> {
-		const entry = sessionMap.get(chatGuid) ?? (await createSession(chatGuid));
+		const storage = resolveSessionStorage(workingDir, chatGuid);
+		const entry = sessionMap.get(chatGuid) ?? (await createSession(storage.mapKey, chatGuid, storage.sessionDir));
 		const { session } = entry;
 		let result: CompactionResult;
 		try {
@@ -789,7 +847,8 @@ export async function createAgentManager(config: AgentManagerConfig) {
 		if (existsSync(contextFile)) {
 			unlinkSync(contextFile);
 		}
-		await createSession(chatGuid);
+		const storage = resolveSessionStorage(workingDir, chatGuid);
+		await createSession(storage.mapKey, chatGuid, storage.sessionDir);
 		console.log(`[agent] new session: ${chatGuid}`);
 	}
 

--- a/src/web/index.ts
+++ b/src/web/index.ts
@@ -3,7 +3,7 @@
 import { existsSync, readFileSync, watch } from "node:fs";
 import { type IncomingMessage, type ServerResponse, createServer } from "node:http";
 import { join } from "node:path";
-import { type AgentManager, BASE_PERSONALITY, buildSystemPrompt } from "../agent.js";
+import { type AgentManager, BASE_PERSONALITY, buildSystemPrompt, resolveSessionStorage } from "../agent.js";
 import { listSkillCatalog } from "../harness.js";
 import { activeMemoryItems, listMemoryNamespaces, loadAllMemoryItems, readCoreMemory } from "../memory.js";
 import type { ModelHealthChecker } from "../model-health.js";
@@ -339,11 +339,21 @@ export function createWebServer(config: WebServerConfig): WebServer {
 				const body = await parseJsonBody(request);
 				const chatGuid = body.chatGuid as string;
 				const prompt = body.prompt as string;
+				const sessionKey = typeof body.sessionKey === "string" ? body.sessionKey : undefined;
+				const ephemeral = body.ephemeral === true;
 				if (!chatGuid || !prompt) {
 					jsonResponse(response, 400, { error: "chatGuid and prompt required" });
 					return;
 				}
-				console.log(`[web] /prompt: ${chatGuid} "${prompt.substring(0, 60)}"`);
+				try {
+					resolveSessionStorage(workingDir, chatGuid, { sessionKey, ephemeral });
+				} catch (error) {
+					jsonResponse(response, 400, { error: String(error) });
+					return;
+				}
+				console.log(
+					`[web] /prompt: ${chatGuid} session=${sessionKey ?? chatGuid} ephemeral=${ephemeral} "${prompt.substring(0, 60)}"`
+				);
 				jsonResponse(response, 200, { ok: true });
 				// Process asynchronously — agent replies are sent to the chat when ready
 				agent
@@ -364,7 +374,7 @@ export function createWebServer(config: WebServerConfig): WebServer {
 								await sender.sendMessage(chatGuid, agentReply.text);
 							}
 						},
-						{ streamingBehavior: "followUp" }
+						{ streamingBehavior: "followUp", sessionKey, ephemeral }
 					)
 					.then(() => {
 						console.log(`[web] /prompt done: ${chatGuid}`);


### PR DESCRIPTION
## 范围
- 从线上提交 1367528 拆出 /prompt 的 sessionKey 与 ephemeral 选项。
- 任务上下文与投递聊天分离；最后一个排队任务完成后清理临时上下文。
- sessionKey 路径校验、按目标聊天隔离；临时会话跳过无意义的结束压缩。
- 重新适配最新 main 的三参数 buildSystemPrompt 和 Memory UI imports，保留上游功能。

## 验证
- npm run check
- ./node_modules/.bin/vitest run：74 项通过

此 PR 不包含调度器、SDK 升级或具体家庭自动化脚本。本次不合并、不部署。
