### PR TITLE
feat(cron): add workspace scheduler and Scheduled Tasks UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ A minimal and self-managing iMessage bot — powered by [pi](https://github.com/
 - **Transparent**: tool calls and reasoning are sent to your iMessage chat, so you can see exactly what it's doing and why
 - **iMessage Integration**: Responds to DMs, SMS, and group chats; identifies who sent each message; understands quoted/reply-to messages
 - **Persistent Reminders**: Schedule one-time messages without per-reminder cron jobs; reminders survive restarts and retry transient failures
-- **Web UI**: browse chat history, toggle replies on/off per chat, live updates — disable with WEB_ENABLED=false and let the agent build your own web UI
+- **Workspace Cron**: Run recurring send, prompt, or local argv jobs from `WORKING_DIR/cron/jobs.json` with timezone and overlap protection
+- **Web UI**: browse chat history, scheduled tasks, logs, and memory — disable with WEB_ENABLED=false and let the agent build your own web UI
 
 # Get Started
 
@@ -35,6 +36,7 @@ pi-imessage install     # install as launchd service (auto-start on boot, restar
 Available at `http://localhost:7750` (configurable via `WEB_HOST` and `WEB_PORT`).
 
 - Chat history with live updates
+- Scheduled recurring jobs, one-time reminders, and recent run results
 - Logs (tail -f style)
 - Memory tab: personality, system prompt, structured memory, skills
 
@@ -75,6 +77,37 @@ edits are snapshotted and can be rolled back. First pass for chats and GitHub
 only reviews the last 48 hours; a new Atom feed with no checkpoint ingests the
 full history currently in that feed.
 
+## Recurring Jobs
+
+Recurring jobs are configured in `WORKING_DIR/cron/jobs.json`. pi-imessage uses
+[Croner](https://github.com/Hexagon/croner) for cron expressions and timezone
+handling. Only the active worker schedules jobs; deployment shadow workers only
+validate and display the configuration.
+
+Supported actions are `send`, `prompt`, and `exec`. Exec jobs use an argv array
+with an absolute executable path and never invoke a shell. Jobs default to
+`Asia/Shanghai`, reject overlapping runs, and append results to
+`WORKING_DIR/cron/runs.jsonl`.
+
+```json
+{
+  "version": 1,
+  "jobs": [
+    {
+      "id": "morning-message",
+      "enabled": true,
+      "schedule": "0 9 * * *",
+      "timezone": "Asia/Shanghai",
+      "action": {
+        "type": "send",
+        "chatGuid": "iMessage;-;+11234567890",
+        "text": "good morning"
+      }
+    }
+  ]
+}
+```
+
 ## API
 
 The agent is aware of these endpoints via its system prompt and can use them as tools (e.g., scheduling a cron job that calls `/prompt`).
@@ -86,6 +119,9 @@ The agent is aware of these endpoints via its system prompt and can use them as 
 | `POST /reminders` | Schedule a persistent one-time reminder; `scheduledAt` requires an explicit timezone | `curl -X POST localhost:7750/reminders -d '{"chatGuid":"iMessage;-;+11234567890","text":"check the oven","scheduledAt":"2026-08-08T21:30:00+08:00"}'` |
 | `GET /reminders` | List reminders; optionally filter with `?status=pending` | `curl 'localhost:7750/reminders?status=pending'` |
 | `DELETE /reminders/:id` | Cancel a pending reminder | `curl -X DELETE localhost:7750/reminders/<id>` |
+| `GET /scheduled/data` | List recurring jobs, one-time reminders, and recent recurring runs | `curl localhost:7750/scheduled/data` |
+| `POST /cron/jobs/:id/run` | Run a configured recurring job immediately | `curl -X POST localhost:7750/cron/jobs/morning-message/run` |
+| `POST /cron/jobs/:id/enabled` | Pause or resume a recurring job and atomically update the workspace config | `curl -X POST localhost:7750/cron/jobs/morning-message/enabled -d '{"enabled":false}'` |
 | `GET /health/model` | Make a live request to the configured default AI model; returns HTTP 200 when healthy or 503 on failure | `curl localhost:7750/health/model`<br>→ `{"ok":true,"model":"openai/gpt-5","latencyMs":842,"checkedAt":"..."}` |
 | `POST /reflect/rollback` | Restore `SYSTEM.md` notes and skills from a snapshot | `curl -X POST localhost:7750/reflect/rollback -d '{"snapshotId":"snap_..."}'` |
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
 				"@earendil-works/pi-ai": "0.84.1",
 				"@earendil-works/pi-coding-agent": "0.84.1",
 				"better-sqlite3": "^12.6.2",
+				"croner": "^9.1.0",
 				"dotenv": "^17.3.1",
 				"eta": "^4.5.1"
 			},
@@ -4264,6 +4265,15 @@
 			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/croner": {
+			"version": "9.1.0",
+			"resolved": "https://registry.npmjs.org/croner/-/croner-9.1.0.tgz",
+			"integrity": "sha512-p9nwwR4qyT5W996vBZhdvBCnMhicY5ytZkR4D1Xj0wuTDEiMnjwR57Q3RXYY/s0EpX6Ay3vgIcfaR+ewGHsi+g==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18.0"
+			}
 		},
 		"node_modules/cross-spawn": {
 			"version": "7.0.6",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
 		"@earendil-works/pi-ai": "0.84.1",
 		"@earendil-works/pi-coding-agent": "0.84.1",
 		"better-sqlite3": "^12.6.2",
+		"croner": "^9.1.0",
 		"dotenv": "^17.3.1",
 		"eta": "^4.5.1"
 	},

--- a/src/__tests__/cron.test.ts
+++ b/src/__tests__/cron.test.ts
@@ -1,0 +1,115 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { type CronConfigFile, type CronService, createCronService, parseCronConfig } from "../cron.js";
+
+function makeWorkingDir(config: CronConfigFile): string {
+	const workingDir = mkdtempSync(join(tmpdir(), "pi-imessage-cron-"));
+	mkdirSync(join(workingDir, "cron"), { recursive: true });
+	writeFileSync(join(workingDir, "cron", "jobs.json"), JSON.stringify(config));
+	return workingDir;
+}
+
+const baseConfig: CronConfigFile = {
+	version: 1,
+	jobs: [
+		{
+			id: "morning-message",
+			name: "Morning message",
+			schedule: "0 9 * * *",
+			timezone: "Asia/Shanghai",
+			action: { type: "send", chatGuid: "iMessage;-;+11234567890", text: "good morning" },
+		},
+	],
+};
+
+describe("parseCronConfig", () => {
+	it("validates jobs and applies defaults", () => {
+		const parsed = parseCronConfig(JSON.stringify(baseConfig));
+		expect(parsed.jobs[0]).toEqual(
+			expect.objectContaining({ id: "morning-message", enabled: true, timezone: "Asia/Shanghai", timeoutSeconds: 300 })
+		);
+	});
+
+	it("rejects duplicate ids, invalid schedules, and relative executables", () => {
+		expect(() =>
+			parseCronConfig(JSON.stringify({ version: 1, jobs: [baseConfig.jobs[0], baseConfig.jobs[0]] }))
+		).toThrow("duplicate");
+		expect(() =>
+			parseCronConfig(JSON.stringify({ version: 1, jobs: [{ ...baseConfig.jobs[0], schedule: "not cron" }] }))
+		).toThrow();
+		expect(() =>
+			parseCronConfig(
+				JSON.stringify({
+					version: 1,
+					jobs: [{ ...baseConfig.jobs[0], action: { type: "exec", argv: ["python3", "job.py"] } }],
+				})
+			)
+		).toThrow("absolute path");
+	});
+});
+
+describe("cron service", () => {
+	let workingDir: string | null = null;
+	let service: CronService | null = null;
+
+	afterEach(async () => {
+		await service?.stop();
+		if (workingDir) rmSync(workingDir, { recursive: true, force: true });
+	});
+
+	it("schedules enabled jobs only after the active service starts", () => {
+		workingDir = makeWorkingDir(baseConfig);
+		service = createCronService({ workingDir, execute: vi.fn() });
+		expect(service.list()[0]?.nextRunAt).toBeNull();
+		service.start();
+		expect(service.list()[0]?.nextRunAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+	});
+
+	it("runs a job manually and persists its result history", async () => {
+		workingDir = makeWorkingDir(baseConfig);
+		const execute = vi.fn().mockResolvedValue(undefined);
+		service = createCronService({ workingDir, execute });
+		const run = await service.runNow("morning-message");
+
+		expect(run.status).toBe("success");
+		expect(execute).toHaveBeenCalledOnce();
+		expect(service.list()[0]?.lastRun?.id).toBe(run.id);
+		expect(readFileSync(join(workingDir, "cron", "runs.jsonl"), "utf-8")).toContain(run.id);
+	});
+
+	it("skips overlapping runs of the same job", async () => {
+		workingDir = makeWorkingDir(baseConfig);
+		let finish: (() => void) | undefined;
+		const execute = vi.fn().mockImplementation(
+			() =>
+				new Promise<void>((resolve) => {
+					finish = resolve;
+				})
+		);
+		service = createCronService({ workingDir, execute });
+		const first = service.runNow("morning-message");
+		const second = await service.runNow("morning-message");
+		expect(second.status).toBe("skipped-overlap");
+		finish?.();
+		expect((await first).status).toBe("success");
+	});
+
+	it("atomically updates enabled state in the workspace config", () => {
+		workingDir = makeWorkingDir(baseConfig);
+		service = createCronService({ workingDir, execute: vi.fn() });
+		const updated = service.setEnabled("morning-message", false);
+		expect(updated.enabled).toBe(false);
+		const onDisk = JSON.parse(readFileSync(join(workingDir, "cron", "jobs.json"), "utf-8"));
+		expect(onDisk.jobs[0].enabled).toBe(false);
+	});
+
+	it("keeps the last valid config when reload rejects a broken file", () => {
+		workingDir = makeWorkingDir(baseConfig);
+		service = createCronService({ workingDir, execute: vi.fn() });
+		writeFileSync(join(workingDir, "cron", "jobs.json"), "{ broken");
+		expect(() => service?.reload()).toThrow();
+		expect(service.list()[0]?.id).toBe("morning-message");
+	});
+});

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -358,14 +358,10 @@ curl 'http://localhost:7750/reminders?status=pending'
 curl -X DELETE http://localhost:7750/reminders/<reminderId>
 \`\`\`
 
-Use system crontab (\`crontab -e\`) only for recurring messages or tasks.
-Example recurring crontab entries:
-\`\`\`
-# Send a static message every morning at 9:00
-0 9 * * * curl -s -X POST http://localhost:7750/send -H "Content-Type: application/json" -d '{"chatGuid":"iMessage;-;+1234567890","text":"good morning"}'
-# Generate and send a daily summary every evening at 21:00
-0 21 * * * curl -s -X POST http://localhost:7750/prompt -H "Content-Type: application/json" -d '{"chatGuid":"iMessage;-;+1234567890","prompt":"generate a daily summary and send it"}'
-\`\`\`
+Use the workspace cron scheduler for recurring messages or tasks. Its reviewed configuration lives at
+\`${workingDir}/cron/jobs.json\`; recurring jobs are visible in the Scheduled Tasks web tab. Prefer \`send\`
+or \`prompt\` actions. Local \`exec\` actions must use an absolute executable plus argv and never a shell command.
+Use system crontab only for bootstrap or host-level maintenance that cannot run inside pi-imessage.
 
 ## Skills (Custom CLI Tools)
 Available skills (read SKILL.md for details, then run the CLI if present):

--- a/src/cron.ts
+++ b/src/cron.ts
@@ -1,0 +1,362 @@
+import { randomUUID } from "node:crypto";
+import { appendFileSync, existsSync, mkdirSync, readFileSync, renameSync, watch, writeFileSync } from "node:fs";
+import { basename, dirname, join } from "node:path";
+import { Cron } from "croner";
+
+export type CronAction =
+	| { type: "send"; chatGuid: string; text: string }
+	| { type: "prompt"; chatGuid: string; prompt: string }
+	| { type: "exec"; argv: string[]; cwd?: string };
+
+export interface CronJobConfig {
+	id: string;
+	name?: string;
+	enabled?: boolean;
+	schedule: string;
+	timezone?: string;
+	timeoutSeconds?: number;
+	action: CronAction;
+}
+
+export interface CronConfigFile {
+	version: 1;
+	jobs: CronJobConfig[];
+}
+
+export type CronRunStatus = "running" | "success" | "failed" | "timeout" | "skipped-overlap";
+
+export interface CronRun {
+	id: string;
+	jobId: string;
+	trigger: "scheduled" | "manual";
+	status: CronRunStatus;
+	startedAt: string;
+	finishedAt: string | null;
+	error: string | null;
+}
+
+export interface CronJobView extends CronJobConfig {
+	enabled: boolean;
+	timezone: string;
+	nextRunAt: string | null;
+	running: boolean;
+	lastRun: CronRun | null;
+}
+
+export interface CronService {
+	start(): void;
+	stop(): Promise<void>;
+	list(): CronJobView[];
+	listRuns(limit?: number): CronRun[];
+	reload(): void;
+	runNow(id: string): Promise<CronRun>;
+	setEnabled(id: string, enabled: boolean): CronJobView;
+	configPath: string;
+}
+
+export interface CronServiceConfig {
+	workingDir: string;
+	execute: (job: CronJobConfig, signal: AbortSignal) => Promise<void>;
+	defaultTimezone?: string;
+	now?: () => Date;
+}
+
+interface ScheduledJob {
+	config: CronJobConfig;
+	cron: Cron;
+}
+
+const DEFAULT_TIMEZONE = "Asia/Shanghai";
+const DEFAULT_TIMEOUT_SECONDS = 300;
+const MAX_RUN_HISTORY = 500;
+
+function requireString(value: unknown, label: string): string {
+	if (typeof value !== "string" || !value.trim()) throw new Error(`${label} must be a non-empty string`);
+	return value.trim();
+}
+
+function validateAction(value: unknown, jobId: string): CronAction {
+	if (!value || typeof value !== "object") throw new Error(`cron job ${jobId}: action must be an object`);
+	const action = value as Record<string, unknown>;
+	const type = requireString(action.type, `cron job ${jobId}: action.type`);
+	if (type === "send") {
+		return {
+			type,
+			chatGuid: requireString(action.chatGuid, `cron job ${jobId}: action.chatGuid`),
+			text: requireString(action.text, `cron job ${jobId}: action.text`),
+		};
+	}
+	if (type === "prompt") {
+		return {
+			type,
+			chatGuid: requireString(action.chatGuid, `cron job ${jobId}: action.chatGuid`),
+			prompt: requireString(action.prompt, `cron job ${jobId}: action.prompt`),
+		};
+	}
+	if (type === "exec") {
+		if (
+			!Array.isArray(action.argv) ||
+			action.argv.length === 0 ||
+			action.argv.some((part) => typeof part !== "string")
+		) {
+			throw new Error(`cron job ${jobId}: action.argv must be a non-empty string array`);
+		}
+		const argv = action.argv.map((part) => part.trim());
+		if (argv.some((part) => !part)) throw new Error(`cron job ${jobId}: action.argv entries cannot be empty`);
+		if (!argv[0]?.startsWith("/")) throw new Error(`cron job ${jobId}: action.argv[0] must be an absolute path`);
+		const cwd = action.cwd === undefined ? undefined : requireString(action.cwd, `cron job ${jobId}: action.cwd`);
+		return { type, argv, cwd };
+	}
+	throw new Error(`cron job ${jobId}: unsupported action type ${type}`);
+}
+
+export function parseCronConfig(raw: string, defaultTimezone = DEFAULT_TIMEZONE): CronConfigFile {
+	const value = JSON.parse(raw) as Record<string, unknown>;
+	if (!value || value.version !== 1 || !Array.isArray(value.jobs)) {
+		throw new Error("cron config must contain version=1 and a jobs array");
+	}
+	const ids = new Set<string>();
+	const jobs = value.jobs.map((candidate, index): CronJobConfig => {
+		if (!candidate || typeof candidate !== "object") throw new Error(`cron job ${index}: must be an object`);
+		const input = candidate as Record<string, unknown>;
+		const id = requireString(input.id, `cron job ${index}: id`);
+		if (!/^[a-zA-Z0-9][a-zA-Z0-9._-]*$/.test(id)) throw new Error(`cron job ${id}: id contains invalid characters`);
+		if (ids.has(id)) throw new Error(`duplicate cron job id: ${id}`);
+		ids.add(id);
+		const schedule = requireString(input.schedule, `cron job ${id}: schedule`);
+		const timezone =
+			input.timezone === undefined ? defaultTimezone : requireString(input.timezone, `cron job ${id}: timezone`);
+		const timeoutSeconds = input.timeoutSeconds === undefined ? DEFAULT_TIMEOUT_SECONDS : Number(input.timeoutSeconds);
+		if (!Number.isFinite(timeoutSeconds) || timeoutSeconds <= 0) {
+			throw new Error(`cron job ${id}: timeoutSeconds must be positive`);
+		}
+		const enabled = input.enabled === undefined ? true : input.enabled;
+		if (typeof enabled !== "boolean") throw new Error(`cron job ${id}: enabled must be boolean`);
+		const name = input.name === undefined ? undefined : requireString(input.name, `cron job ${id}: name`);
+		const action = validateAction(input.action, id);
+
+		// Construction validates both the cron expression and IANA timezone.
+		const validator = new Cron(schedule, { timezone, paused: true });
+		validator.stop();
+		return { id, name, enabled, schedule, timezone, timeoutSeconds, action };
+	});
+	return { version: 1, jobs };
+}
+
+function loadRunHistory(path: string): CronRun[] {
+	if (!existsSync(path)) return [];
+	try {
+		return readFileSync(path, "utf-8")
+			.split("\n")
+			.filter(Boolean)
+			.slice(-MAX_RUN_HISTORY)
+			.map((line) => JSON.parse(line) as CronRun);
+	} catch (error) {
+		console.warn(`[cron] could not load run history: ${error instanceof Error ? error.message : String(error)}`);
+		return [];
+	}
+}
+
+export function createCronService(config: CronServiceConfig): CronService {
+	const cronDir = join(config.workingDir, "cron");
+	const configPath = join(cronDir, "jobs.json");
+	const runsPath = join(cronDir, "runs.jsonl");
+	const defaultTimezone = config.defaultTimezone ?? DEFAULT_TIMEZONE;
+	const now = config.now ?? (() => new Date());
+	mkdirSync(cronDir, { recursive: true });
+	if (!existsSync(configPath)) {
+		writeFileSync(configPath, `${JSON.stringify({ version: 1, jobs: [] }, null, 2)}\n`, "utf-8");
+	}
+
+	let currentConfig = parseCronConfig(readFileSync(configPath, "utf-8"), defaultTimezone);
+	const scheduled = new Map<string, ScheduledJob>();
+	let runs = loadRunHistory(runsPath);
+	const activeRuns = new Map<string, Promise<CronRun>>();
+	let started = false;
+	let closed = false;
+	let watcher: ReturnType<typeof watch> | null = null;
+	let reloadTimer: ReturnType<typeof setTimeout> | null = null;
+
+	function appendRun(run: CronRun): void {
+		runs.push(run);
+		if (runs.length > MAX_RUN_HISTORY) runs = runs.slice(-MAX_RUN_HISTORY);
+		appendFileSync(runsPath, `${JSON.stringify(run)}\n`, "utf-8");
+	}
+
+	function lastRun(jobId: string): CronRun | null {
+		for (let index = runs.length - 1; index >= 0; index--) {
+			if (runs[index]?.jobId === jobId) return runs[index] ?? null;
+		}
+		return null;
+	}
+
+	function stopSchedules(): void {
+		for (const item of scheduled.values()) item.cron.stop();
+		scheduled.clear();
+	}
+
+	function scheduleJobs(): void {
+		stopSchedules();
+		if (!started) return;
+		for (const job of currentConfig.jobs) {
+			if (job.enabled === false) continue;
+			const cron = new Cron(
+				job.schedule,
+				{
+					name: job.id,
+					timezone: job.timezone ?? defaultTimezone,
+					protect: () => recordOverlap(job, "scheduled"),
+					catch: (error) => console.error(`[cron] uncaught error in ${job.id}:`, error),
+					unref: true,
+				},
+				async () => {
+					await beginRun(job, "scheduled");
+				}
+			);
+			scheduled.set(job.id, { config: job, cron });
+		}
+		console.log(`[cron] loaded ${currentConfig.jobs.length} jobs (${scheduled.size} enabled)`);
+	}
+
+	function recordOverlap(job: CronJobConfig, trigger: "scheduled" | "manual"): CronRun {
+		const timestamp = now().toISOString();
+		const run: CronRun = {
+			id: randomUUID(),
+			jobId: job.id,
+			trigger,
+			status: "skipped-overlap",
+			startedAt: timestamp,
+			finishedAt: timestamp,
+			error: "previous run is still active",
+		};
+		appendRun(run);
+		console.warn(`[cron] skipped overlapping run: ${job.id}`);
+		return run;
+	}
+
+	async function executeJob(job: CronJobConfig, trigger: "scheduled" | "manual"): Promise<CronRun> {
+		const controller = new AbortController();
+		const timeoutMs = (job.timeoutSeconds ?? DEFAULT_TIMEOUT_SECONDS) * 1_000;
+		let timeout: ReturnType<typeof setTimeout> | null = null;
+		const timeoutPromise = new Promise<never>((_resolve, reject) => {
+			timeout = setTimeout(() => {
+				const error = new Error(`timed out after ${timeoutMs}ms`);
+				controller.abort(error);
+				reject(error);
+			}, timeoutMs);
+			timeout.unref();
+		});
+		const run: CronRun = {
+			id: randomUUID(),
+			jobId: job.id,
+			trigger,
+			status: "running",
+			startedAt: now().toISOString(),
+			finishedAt: null,
+			error: null,
+		};
+		console.log(`[cron] run start: ${job.id} trigger=${trigger} action=${job.action.type}`);
+		try {
+			await Promise.race([config.execute(job, controller.signal), timeoutPromise]);
+			run.status = "success";
+		} catch (error) {
+			const reason = error instanceof Error ? error.message : String(error);
+			run.status = controller.signal.aborted ? "timeout" : "failed";
+			run.error = reason;
+		} finally {
+			if (timeout) clearTimeout(timeout);
+			run.finishedAt = now().toISOString();
+			appendRun(run);
+			console.log(
+				`[cron] run end: ${job.id} status=${run.status}${run.error ? ` error=${JSON.stringify(run.error)}` : ""}`
+			);
+		}
+		return run;
+	}
+
+	function beginRun(job: CronJobConfig, trigger: "scheduled" | "manual"): Promise<CronRun> {
+		if (activeRuns.has(job.id)) return Promise.resolve(recordOverlap(job, trigger));
+		const promise = executeJob(job, trigger).finally(() => activeRuns.delete(job.id));
+		activeRuns.set(job.id, promise);
+		return promise;
+	}
+
+	function reload(): void {
+		const candidate = parseCronConfig(readFileSync(configPath, "utf-8"), defaultTimezone);
+		currentConfig = candidate;
+		scheduleJobs();
+	}
+
+	function writeConfig(next: CronConfigFile): void {
+		const temporary = `${configPath}.tmp-${process.pid}`;
+		writeFileSync(temporary, `${JSON.stringify(next, null, 2)}\n`, "utf-8");
+		renameSync(temporary, configPath);
+	}
+
+	function list(): CronJobView[] {
+		return currentConfig.jobs.map((job) => ({
+			...job,
+			enabled: job.enabled !== false,
+			timezone: job.timezone ?? defaultTimezone,
+			nextRunAt: scheduled.get(job.id)?.cron.nextRun()?.toISOString() ?? null,
+			running: activeRuns.has(job.id),
+			lastRun: lastRun(job.id),
+		}));
+	}
+
+	return {
+		configPath,
+		start(): void {
+			if (started) return;
+			if (closed) throw new Error("cron service is closed");
+			started = true;
+			scheduleJobs();
+			watcher = watch(dirname(configPath), (_event, filename) => {
+				if (basename(filename?.toString() ?? "") !== basename(configPath)) return;
+				if (reloadTimer) clearTimeout(reloadTimer);
+				reloadTimer = setTimeout(() => {
+					reloadTimer = null;
+					try {
+						reload();
+						console.log(`[cron] reloaded ${configPath}`);
+					} catch (error) {
+						console.error(
+							`[cron] reload rejected; keeping last valid config: ${error instanceof Error ? error.message : String(error)}`
+						);
+					}
+				}, 200);
+			});
+			watcher.on("error", (error) => console.error("[cron] config watcher error:", error));
+		},
+		async stop(): Promise<void> {
+			if (closed) return;
+			started = false;
+			stopSchedules();
+			watcher?.close();
+			watcher = null;
+			if (reloadTimer) clearTimeout(reloadTimer);
+			await Promise.allSettled(activeRuns.values());
+			closed = true;
+		},
+		list,
+		listRuns(limit = 100): CronRun[] {
+			return runs.slice(-Math.max(0, limit)).reverse();
+		},
+		reload,
+		runNow(id: string): Promise<CronRun> {
+			const job = currentConfig.jobs.find((item) => item.id === id);
+			if (!job) throw new Error(`cron job not found: ${id}`);
+			return beginRun(job, "manual");
+		},
+		setEnabled(id: string, enabled: boolean): CronJobView {
+			const index = currentConfig.jobs.findIndex((item) => item.id === id);
+			if (index < 0) throw new Error(`cron job not found: ${id}`);
+			const jobs = currentConfig.jobs.map((job, jobIndex) => (jobIndex === index ? { ...job, enabled } : job));
+			const next: CronConfigFile = { version: 1, jobs };
+			writeConfig(next);
+			currentConfig = next;
+			scheduleJobs();
+			return list().find((job) => job.id === id) as CronJobView;
+		},
+	};
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,9 +3,11 @@
  */
 
 import "dotenv/config";
+import { spawn } from "node:child_process";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { createAgentManager } from "./agent.js";
+import { type CronJobConfig, createCronService } from "./cron.js";
 import { createIMessageBot } from "./imessage.js";
 import { createAppLogger, createDigestLogger } from "./logger.js";
 import { createModelHealthChecker } from "./model-health.js";
@@ -57,6 +59,67 @@ async function main() {
 			await sender.sendMessage(reminder.chatGuid, reminder.text);
 		},
 	});
+
+	async function executeCronJob(job: CronJobConfig, signal: AbortSignal): Promise<void> {
+		const action = job.action;
+		if (action.type === "send") {
+			echoFilter.remember(action.chatGuid, action.text);
+			await sender.sendMessage(action.chatGuid, action.text);
+			return;
+		}
+		if (action.type === "prompt") {
+			await agent.processMessage(
+				{
+					chatGuid: action.chatGuid,
+					sender: `cron:${job.id}`,
+					text: action.prompt,
+					messageType: "imessage",
+					groupName: "",
+					replyToText: null,
+					attachments: [],
+					images: [],
+				},
+				async (reply) => {
+					if (reply.kind !== "assistant") return;
+					echoFilter.remember(action.chatGuid, reply.text);
+					await sender.sendMessage(action.chatGuid, reply.text);
+				},
+				{ streamingBehavior: "followUp" }
+			);
+			return;
+		}
+
+		await new Promise<void>((resolve, reject) => {
+			const [command, ...args] = action.argv;
+			if (!command) {
+				reject(new Error("exec action has no command"));
+				return;
+			}
+			const child = spawn(command, args, {
+				cwd: action.cwd,
+				shell: false,
+				stdio: ["ignore", "pipe", "pipe"],
+				signal,
+			});
+			let output = "";
+			const collect = (chunk: Buffer) => {
+				output = `${output}${chunk.toString()}`.slice(-16_000);
+			};
+			child.stdout.on("data", collect);
+			child.stderr.on("data", collect);
+			child.on("error", reject);
+			child.on("exit", (code, childSignal) => {
+				if (code === 0) {
+					if (output.trim()) console.log(`[cron] ${job.id} output: ${output.trim()}`);
+					resolve();
+				} else {
+					reject(new Error(`command exited code=${code ?? "null"} signal=${childSignal ?? "none"}: ${output.trim()}`));
+				}
+			});
+		});
+	}
+
+	const cron = createCronService({ workingDir, execute: executeCronJob });
 	const web = webEnabled
 		? createWebServer({
 				workingDir,
@@ -69,6 +132,7 @@ async function main() {
 				agent,
 				checkModelHealth,
 				reminders,
+				cron,
 			})
 		: null;
 
@@ -78,6 +142,7 @@ async function main() {
 		watcher.start();
 		bot.start();
 		reminders.start();
+		cron.start();
 	}
 	if (web) web.start();
 
@@ -89,7 +154,7 @@ async function main() {
 		if (workerEnabled) {
 			watcher.stop();
 			bot.stop();
-			await reminders.stop();
+			await Promise.all([reminders.stop(), cron.stop()]);
 			reflectionScheduler?.stop();
 		}
 		await web?.stop();

--- a/src/web/index.ts
+++ b/src/web/index.ts
@@ -4,6 +4,7 @@ import { existsSync, readFileSync, watch } from "node:fs";
 import { type IncomingMessage, type ServerResponse, createServer } from "node:http";
 import { join } from "node:path";
 import { type AgentManager, BASE_PERSONALITY, buildSystemPrompt } from "../agent.js";
+import type { CronService } from "../cron.js";
 import { listSkillCatalog } from "../harness.js";
 import { activeMemoryItems, listMemoryNamespaces, loadAllMemoryItems, readCoreMemory } from "../memory.js";
 import type { ModelHealthChecker } from "../model-health.js";
@@ -14,7 +15,7 @@ import type { MessageSender } from "../send.js";
 import type { Settings } from "../settings.js";
 import type { AgentReply } from "../types.js";
 import { getChatBlocks } from "./data.js";
-import { type MemoryPageData, renderLogsPage, renderMemoryPage, renderPage } from "./render.js";
+import { type MemoryPageData, renderLogsPage, renderMemoryPage, renderPage, renderScheduledPage } from "./render.js";
 
 export interface WebServerConfig {
 	workingDir: string;
@@ -27,6 +28,7 @@ export interface WebServerConfig {
 	agent: AgentManager;
 	checkModelHealth: ModelHealthChecker;
 	reminders: ReminderService;
+	cron: CronService;
 }
 
 export interface WebServer {
@@ -113,8 +115,19 @@ function readMemories(workingDir: string): MemoryPageData {
 }
 
 export function createWebServer(config: WebServerConfig): WebServer {
-	const { workingDir, host, port, getSettings, setSettings, sender, echoFilter, agent, checkModelHealth, reminders } =
-		config;
+	const {
+		workingDir,
+		host,
+		port,
+		getSettings,
+		setSettings,
+		sender,
+		echoFilter,
+		agent,
+		checkModelHealth,
+		reminders,
+		cron,
+	} = config;
 	const sseClients = new Set<ServerResponse>();
 	let fsWatcher: ReturnType<typeof watch> | null = null;
 	let debounceTimer: ReturnType<typeof setTimeout> | null = null;
@@ -195,6 +208,53 @@ export function createWebServer(config: WebServerConfig): WebServer {
 		// Memory data API (JSON)
 		if (url.pathname === "/memory/data" && request.method === "GET") {
 			jsonResponse(response, 200, readMemories(workingDir));
+			return;
+		}
+
+		// Unified recurring jobs and one-time reminders page.
+		if (url.pathname === "/scheduled" && request.method === "GET") {
+			const html = renderScheduledPage({
+				jobs: cron.list(),
+				runs: cron.listRuns(100),
+				reminders: reminders.list(),
+				configPath: cron.configPath,
+			});
+			response.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });
+			response.end(html);
+			return;
+		}
+
+		if (url.pathname === "/scheduled/data" && request.method === "GET") {
+			jsonResponse(response, 200, {
+				jobs: cron.list(),
+				runs: cron.listRuns(100),
+				reminders: reminders.list(),
+				configPath: cron.configPath,
+			});
+			return;
+		}
+
+		const cronRunMatch = url.pathname.match(/^\/cron\/jobs\/([^/]+)\/run$/);
+		if (request.method === "POST" && cronRunMatch) {
+			try {
+				const run = await cron.runNow(decodeURIComponent(cronRunMatch[1]));
+				jsonResponse(response, 200, { ok: true, run });
+			} catch (error) {
+				jsonResponse(response, 404, { error: error instanceof Error ? error.message : String(error) });
+			}
+			return;
+		}
+
+		const cronToggleMatch = url.pathname.match(/^\/cron\/jobs\/([^/]+)\/enabled$/);
+		if (request.method === "POST" && cronToggleMatch) {
+			try {
+				const body = await parseJsonBody(request);
+				if (typeof body.enabled !== "boolean") throw new Error("enabled must be boolean");
+				const job = cron.setEnabled(decodeURIComponent(cronToggleMatch[1]), body.enabled);
+				jsonResponse(response, 200, { ok: true, job });
+			} catch (error) {
+				jsonResponse(response, 400, { error: error instanceof Error ? error.message : String(error) });
+			}
 			return;
 		}
 

--- a/src/web/render.ts
+++ b/src/web/render.ts
@@ -3,6 +3,8 @@
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { Eta } from "eta";
+import type { CronJobView, CronRun } from "../cron.js";
+import type { Reminder } from "../reminders.js";
 import { isReplyEnabled } from "../settings.js";
 import type { Settings } from "../settings.js";
 import { firstLinePreview, senderLabel } from "../store.js";
@@ -75,6 +77,17 @@ export function renderPage(blocks: ChatBlock[], settings: Settings): string {
 
 export function renderLogsPage(appLog: string, digestLog: string): string {
 	return eta.render("logs", { appLog, digestLog });
+}
+
+export interface ScheduledPageData {
+	jobs: CronJobView[];
+	runs: CronRun[];
+	reminders: Reminder[];
+	configPath: string;
+}
+
+export function renderScheduledPage(data: ScheduledPageData): string {
+	return eta.render("scheduled", data);
 }
 
 export interface MemoryItemView {

--- a/src/web/templates/logs.eta
+++ b/src/web/templates/logs.eta
@@ -20,6 +20,7 @@ pre { white-space: pre-wrap; word-break: break-word; opacity: .7; margin: 0 }
 
 <nav>
   <a href="/">Recent Chats</a>
+  <a href="/scheduled">Scheduled</a>
   <a href="/logs" class="active">Logs</a>
   <a href="/memory">Memory</a>
 </nav>

--- a/src/web/templates/memory.eta
+++ b/src/web/templates/memory.eta
@@ -30,6 +30,7 @@ pre { white-space: pre-wrap; word-break: break-word; opacity: .7; margin: 0 }
 
 <nav>
   <a href="/">Recent Chats</a>
+  <a href="/scheduled">Scheduled</a>
   <a href="/logs">Logs</a>
   <a href="/memory" class="active">Memory</a>
 </nav>

--- a/src/web/templates/page.eta
+++ b/src/web/templates/page.eta
@@ -31,6 +31,7 @@ td { vertical-align: top; padding: 1px 0 }
 
 <nav>
   <a href="/" class="active">Recent Chats</a>
+  <a href="/scheduled">Scheduled</a>
   <a href="/logs">Logs</a>
   <a href="/memory">Memory</a>
 </nav>

--- a/src/web/templates/scheduled.eta
+++ b/src/web/templates/scheduled.eta
@@ -1,0 +1,131 @@
+<!DOCTYPE html>
+<html><head><meta charset="UTF-8"><title>blue — scheduled tasks</title>
+<style>
+* { margin: 0; padding: 0; box-sizing: border-box }
+body { background: #111; color: #ccc; font: 13px/1.6 monospace; display: flex; height: 100vh; overflow: hidden }
+::-webkit-scrollbar { width: 8px; height: 8px }
+::-webkit-scrollbar-track { background: transparent }
+::-webkit-scrollbar-thumb { background: #2a2a2a }
+* { scrollbar-width: thin; scrollbar-color: #2a2a2a transparent }
+nav { width: 112px; flex-shrink: 0; padding: 40px 16px; border-right: 1px solid #1a1a1a }
+nav a { display: block; color: inherit; text-decoration: none; line-height: 2.4; opacity: .35 }
+nav a:hover, nav a.active { opacity: 1 }
+.content { flex: 1; padding: 40px; overflow-y: auto }
+h2 { font-size: 13px; font-weight: normal; opacity: .5; margin: 0 0 12px }
+.section { margin-bottom: 32px }
+.meta { opacity: .35; margin-bottom: 12px; word-break: break-all }
+table { width: 100%; border-collapse: collapse; background: #1a1a1a }
+th, td { padding: 9px 12px; border-bottom: 1px solid #252525; text-align: left; vertical-align: top }
+th { opacity: .4; font-weight: normal; white-space: nowrap }
+.dim { opacity: .4 }
+.good { color: #93b58c }
+.bad { color: #c47f7f }
+.running { color: #c7b477 }
+.action { max-width: 420px; white-space: pre-wrap; word-break: break-word }
+button { background: none; border: 1px solid #333; color: #aaa; font: 12px monospace; padding: 2px 7px; cursor: pointer; margin-right: 4px }
+button:hover { border-color: #777; color: #ddd }
+.empty { padding: 14px; background: #1a1a1a; opacity: .35 }
+</style></head><body>
+
+<nav>
+  <a href="/">Recent Chats</a>
+  <a href="/scheduled" class="active">Scheduled</a>
+  <a href="/logs">Logs</a>
+  <a href="/memory">Memory</a>
+</nav>
+
+<div class="content">
+  <div class="section">
+    <h2>Recurring jobs</h2>
+    <div class="meta">config: <%= it.configPath %></div>
+<% if (it.jobs.length === 0) { %>
+    <div class="empty">no recurring jobs configured</div>
+<% } else { %>
+    <table>
+      <thead><tr><th>job</th><th>schedule</th><th>next run</th><th>action</th><th>last result</th><th>controls</th></tr></thead>
+      <tbody>
+<% it.jobs.forEach(function(job) { %>
+        <tr>
+          <td><%= job.name || job.id %><br><span class="dim"><%= job.enabled ? 'enabled' : 'paused' %><%= job.running ? ' / running' : '' %></span></td>
+          <td><%= job.schedule %><br><span class="dim"><%= job.timezone %></span></td>
+          <td><%= job.nextRunAt || '—' %></td>
+          <td class="action"><%= JSON.stringify(job.action) %></td>
+          <td class="<%= job.lastRun && job.lastRun.status === 'success' ? 'good' : job.lastRun ? 'bad' : 'dim' %>">
+            <%= job.lastRun ? job.lastRun.status : 'never' %><br>
+            <span class="dim"><%= job.lastRun ? job.lastRun.finishedAt || job.lastRun.startedAt : '' %></span>
+          </td>
+          <td>
+            <button onclick="runJob('<%= job.id %>')">run</button>
+            <button onclick="toggleJob('<%= job.id %>', <%= !job.enabled %>)"><%= job.enabled ? 'pause' : 'resume' %></button>
+          </td>
+        </tr>
+<% }) %>
+      </tbody>
+    </table>
+<% } %>
+  </div>
+
+  <div class="section">
+    <h2>One-time reminders</h2>
+<% const visibleReminders = it.reminders.filter(function(reminder) { return reminder.status === 'pending' }).concat(it.reminders.filter(function(reminder) { return reminder.status !== 'pending' }).slice(-20)); %>
+<% if (visibleReminders.length === 0) { %>
+    <div class="empty">no reminders</div>
+<% } else { %>
+    <table>
+      <thead><tr><th>status</th><th>scheduled</th><th>chat</th><th>text</th><th>result</th></tr></thead>
+      <tbody>
+<% visibleReminders.forEach(function(reminder) { %>
+        <tr>
+          <td class="<%= reminder.status === 'delivered' ? 'good' : reminder.status === 'pending' ? 'running' : 'bad' %>"><%= reminder.status %></td>
+          <td><%= reminder.scheduledAt %></td>
+          <td><%= reminder.chatGuid %></td>
+          <td class="action"><%= reminder.text %></td>
+          <td><span class="dim"><%= reminder.lastError || (reminder.deliveredAt || '') %></span></td>
+        </tr>
+<% }) %>
+      </tbody>
+    </table>
+<% } %>
+  </div>
+
+  <div class="section">
+    <h2>Recent recurring runs</h2>
+<% if (it.runs.length === 0) { %>
+    <div class="empty">no runs recorded</div>
+<% } else { %>
+    <table>
+      <thead><tr><th>job</th><th>trigger</th><th>status</th><th>started</th><th>finished / error</th></tr></thead>
+      <tbody>
+<% it.runs.slice(0, 50).forEach(function(run) { %>
+        <tr>
+          <td><%= run.jobId %></td>
+          <td><%= run.trigger %></td>
+          <td class="<%= run.status === 'success' ? 'good' : run.status === 'running' ? 'running' : 'bad' %>"><%= run.status %></td>
+          <td><%= run.startedAt %></td>
+          <td><%= run.finishedAt || '—' %><% if (run.error) { %><br><span class="bad"><%= run.error %></span><% } %></td>
+        </tr>
+<% }) %>
+      </tbody>
+    </table>
+<% } %>
+  </div>
+</div>
+
+<script>
+async function runJob(id) {
+  const response = await fetch('/cron/jobs/' + encodeURIComponent(id) + '/run', { method: 'POST' });
+  if (!response.ok) alert(await response.text());
+  location.reload();
+}
+async function toggleJob(id, enabled) {
+  const response = await fetch('/cron/jobs/' + encodeURIComponent(id) + '/enabled', {
+    method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ enabled })
+  });
+  if (!response.ok) alert(await response.text());
+  location.reload();
+}
+const es = new EventSource('/events');
+es.addEventListener('update', () => location.reload());
+setInterval(() => location.reload(), 30000);
+</script>
+</body></html>


### PR DESCRIPTION
## 范围
- 从线上历史提交 82445f2 拆出 Croner 调度器、send/prompt/argv-only exec、运行记录和 Scheduled Tasks 页面。
- 将 7008fee 中混入的调度器 system prompt 指引移入本 PR；远端审查部署脚本另开 PR。
- 基于最新 main 重新适配，保留 main 的 Nightly Reflection 和统一 Memory UI，不回退其代码。
- 只有 active worker 执行任务；不会自动迁移或开启本机任务。

## 验证
- npm run check
- ./node_modules/.bin/vitest run：77 项通过

仅整理为可审阅 diff。本次未合并、发布、重启或部署。
