### PR TITLE
Batch consecutive pending text messages by sender

### DIFF
--- a/docs/busy-text-batching.md
+++ b/docs/busy-text-batching.md
@@ -1,0 +1,17 @@
+Busy-only text batching (v1)
+
+Idle chats start immediately. While a chat is processing a turn, consecutive pending messages from the same sender can become one model input. Other chats remain concurrent.
+
+<img width="1000" alt="A1 and A2 form one batch; B1 and A3 remain separate, preserving sender boundaries and order." src="https://raw.githubusercontent.com/daya0576/pi-imessage/8aab11190b3127dd283f2724cd25992f3512ebfb/issue-23/02-sender-boundary.png">
+
+Only non-empty plain text from a known sender is eligible. Slash-prefixed messages, quotes, attachments, loaded images, and sender/chat metadata changes split batches. At most eight messages and 8,000 UTF-16 code units (including separators) can be joined. Larger individual messages still run unchanged.
+
+The active turn never absorbs new input. The next batch is frozen before processing. Each original runs through logging, echo filtering, storage, and preparation separately; surviving texts are joined with two newlines for one agent call. No synthetic joined incoming entry is written to the chat log. Streaming and tool replies are unchanged: one agent call may still emit multiple outgoing messages.
+
+/stop still bypasses the per-chat queue. A boundary marker prevents messages from opposite sides of /stop from merging. It does not introduce cancellation of already-pending messages.
+
+No debounce, steering, silence policy, model switch, automatic batch replay, or new production setting. The HTTP automation path is unchanged. Existing agent retry and send semantics remain unchanged; this does not add durable in-flight acknowledgement or exactly-once delivery across crashes.
+
+Tests cover immediate start, busy-only merging, sender and content boundaries, independent chats, limits, stop boundaries, error isolation, original-message logging, echo filtering, log-only settings, and command dispatch. Integration tests use the actual bot/pipeline with a mocked agent and sender, not live model or Messages calls.
+
+Related experiment: https://github.com/daya0576/pi-imessage/issues/23

--- a/src/__tests__/imessage-batching.test.ts
+++ b/src/__tests__/imessage-batching.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it, vi } from "vitest";
+import type { AgentManager } from "../agent.js";
+import { createIMessageBot } from "../imessage.js";
+import { createMessagePipeline } from "../pipeline.js";
+import { createAsyncQueue } from "../queue.js";
+import { createSelfEchoFilter } from "../self-echo.js";
+import type { MessageSender } from "../send.js";
+import type { ChatStore } from "../store.js";
+import type { AgentReply, IncomingMessage } from "../types.js";
+
+function message(text: string, overrides: Partial<IncomingMessage> = {}): IncomingMessage {
+	return {
+		chatGuid: "test-group",
+		sender: "alice",
+		text,
+		messageType: "group",
+		groupName: "Fixture",
+		replyToText: null,
+		attachments: [],
+		images: [],
+		...overrides,
+	};
+}
+
+function fixture() {
+	let release = () => {};
+	const gate = new Promise<void>((resolve) => {
+		release = resolve;
+	});
+	const processMessage = vi.fn(async (incoming: IncomingMessage, reply: (r: AgentReply) => Promise<void>) => {
+		if (incoming.text === "busy") await gate;
+		await reply({ kind: "assistant", text: `reply:${incoming.text}` });
+	});
+	const stop = vi.fn(async () => {});
+	const agent = {
+		processMessage,
+		stop,
+		newSession: vi.fn(async () => {}),
+		getSessionStatus: vi.fn(async () => "status"),
+	};
+	const store = { archiveImages: vi.fn(async () => []), log: vi.fn(async () => {}) };
+	const sender = { sendMessage: vi.fn(async () => {}), sendAttachment: vi.fn(async () => {}) };
+	const echoFilter = createSelfEchoFilter();
+	const queue = createAsyncQueue<IncomingMessage>();
+	const settings = { chatAllowlist: { whitelist: ["*"], blacklist: [] as string[] } };
+	const log = vi.fn();
+	const bot = createIMessageBot({
+		queue,
+		agent: agent as unknown as AgentManager,
+		sender: sender as unknown as MessageSender,
+		store: store as unknown as ChatStore,
+		echoFilter,
+		getSettings: () => settings,
+		digestLogger: { log, close() {} },
+	});
+	bot.start();
+	queue.push(message("busy"));
+	return { queue, bot, processMessage, stop, agent, store, sender, echoFilter, release, settings, log };
+}
+
+async function waitForPulls() {
+	// Allow the actual consumer to transfer pending inputs to its per-chat queue.
+	for (let i = 0; i < 30; i++) await Promise.resolve();
+}
+
+describe("actual bot pipeline with busy batching", () => {
+	it("stores each source once, filters echoes separately, and sends one joined turn", async () => {
+		const f = fixture();
+		try {
+			await vi.waitFor(() => expect(f.processMessage).toHaveBeenCalledTimes(1));
+			f.echoFilter.remember("test-group", "echo");
+			f.queue.push(message("one"));
+			f.queue.push(message("echo"));
+			f.queue.push(message("two"));
+			await waitForPulls();
+			expect(f.processMessage).toHaveBeenCalledTimes(1);
+			f.release();
+			await vi.waitFor(() => expect(f.sender.sendMessage).toHaveBeenCalledTimes(2));
+			expect(f.processMessage.mock.calls.map(([m]) => m.text)).toEqual(["busy", "one\n\ntwo"]);
+			const originals = f.store.log.mock.calls as unknown as [string, { fromAgent: boolean; text: string }][];
+			expect(originals.filter(([, e]) => !e.fromAgent).map(([, e]) => e.text)).toEqual(["busy", "one", "two"]);
+			expect(f.log.mock.calls.filter(([line]) => String(line).includes("<-"))).toHaveLength(4);
+		} finally {
+			f.release();
+			f.bot.stop();
+		}
+	});
+
+	it("executes /new alone between the surrounding text turns", async () => {
+		const f = fixture();
+		try {
+			await vi.waitFor(() => expect(f.processMessage).toHaveBeenCalledTimes(1));
+			f.queue.push(message("before"));
+			f.queue.push(message("/new"));
+			f.queue.push(message("after"));
+			await waitForPulls();
+			f.release();
+			await vi.waitFor(() => expect(f.sender.sendMessage).toHaveBeenCalledTimes(5));
+			expect(f.agent.newSession).toHaveBeenCalledOnce();
+			expect(f.processMessage.mock.calls.map(([m]) => m.text)).toEqual(["busy", "before", "after"]);
+		} finally {
+			f.release();
+			f.bot.stop();
+		}
+	});
+
+	it("keeps /stop immediate and prevents merging text from either side of it", async () => {
+		const f = fixture();
+		try {
+			await vi.waitFor(() => expect(f.processMessage).toHaveBeenCalledTimes(1));
+			f.queue.push(message("before-stop"));
+			f.queue.push(message("/stop"));
+			f.queue.push(message("after-stop"));
+			await vi.waitFor(() => expect(f.stop).toHaveBeenCalledOnce());
+			await waitForPulls();
+			expect(f.processMessage).toHaveBeenCalledTimes(1);
+			f.release();
+			await vi.waitFor(() => expect(f.sender.sendMessage).toHaveBeenCalledTimes(4));
+			expect(f.processMessage.mock.calls.map(([m]) => m.text)).toEqual(["busy", "before-stop", "after-stop"]);
+		} finally {
+			f.release();
+			f.bot.stop();
+		}
+	});
+
+	it("preserves log-only settings for every pending source", async () => {
+		const f = fixture();
+		try {
+			await vi.waitFor(() => expect(f.processMessage).toHaveBeenCalledTimes(1));
+			f.queue.push(message("one"));
+			f.queue.push(message("two"));
+			await waitForPulls();
+			f.settings.chatAllowlist.blacklist.push("test-group");
+			f.release();
+			await vi.waitFor(() => expect(f.store.log).toHaveBeenCalledTimes(4));
+			expect(f.processMessage).toHaveBeenCalledTimes(1);
+		} finally {
+			f.release();
+			f.bot.stop();
+		}
+	});
+});
+
+describe("batch preparation", () => {
+	it("isolates a preparation failure without discarding the other source messages", async () => {
+		const errors = vi.spyOn(console, "error").mockImplementation(() => {});
+		const pipeline = createMessagePipeline();
+		const observed: string[] = [];
+		pipeline.before((_chat, incoming, outgoing) => {
+			observed.push(incoming.text ?? "");
+			if (incoming.text === "bad") throw new Error("fixture preparation failure");
+			return outgoing;
+		});
+		const start = vi.fn(async () => {});
+		pipeline.start(start);
+		try {
+			await pipeline.processBatch([message("one"), message("bad"), message("two")]);
+			expect(observed).toEqual(["one", "bad", "two"]);
+			expect(start).toHaveBeenCalledOnce();
+			expect(start.mock.calls[0]).toEqual(expect.arrayContaining([expect.objectContaining({ text: "one\n\ntwo" })]));
+			expect(errors).toHaveBeenCalledOnce();
+		} finally {
+			errors.mockRestore();
+		}
+	});
+
+	it("does not call the agent when all originals are filtered out", async () => {
+		const pipeline = createMessagePipeline();
+		pipeline.before((_chat, _incoming, outgoing) => ({ ...outgoing, shouldContinue: false }));
+		const start = vi.fn(async () => {});
+		pipeline.start(start);
+		await pipeline.processBatch([message("one"), message("two")]);
+		expect(start).not.toHaveBeenCalled();
+	});
+
+	it("rejects cross-sender batches before running even the logging tasks", async () => {
+		const pipeline = createMessagePipeline();
+		const before = vi.fn((_chat, _incoming, outgoing) => outgoing);
+		pipeline.before(before);
+		await expect(pipeline.processBatch([message("one"), message("two", { sender: "bob" })])).rejects.toThrow(
+			"boundary"
+		);
+		expect(before).not.toHaveBeenCalled();
+	});
+});

--- a/src/__tests__/message-batch.test.ts
+++ b/src/__tests__/message-batch.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it, vi } from "vitest";
+import { createMessageBatchQueue, joinTextBatch } from "../message-batch.js";
+import type { IncomingMessage } from "../types.js";
+
+function message(text: string | null, overrides: Partial<IncomingMessage> = {}): IncomingMessage {
+	return {
+		chatGuid: "group-a",
+		sender: "alice",
+		text,
+		messageType: "group",
+		groupName: "Test",
+		replyToText: null,
+		attachments: [],
+		images: [],
+		...overrides,
+	};
+}
+
+function fixture() {
+	let release = () => {};
+	const gate = new Promise<void>((resolve) => {
+		release = resolve;
+	});
+	const seen: IncomingMessage[][] = [];
+	const queue = createMessageBatchQueue(async (batch) => {
+		seen.push(batch);
+		if (batch[0].text === "busy") await gate;
+	});
+	queue.enqueue(message("busy"));
+	return { queue, seen, release };
+}
+
+function texts(seen: IncomingMessage[][]) {
+	return seen.map((batch) => batch.map((item) => item.text));
+}
+
+describe("busy-only text batching", () => {
+	it("starts idle work synchronously, without a debounce window", () => {
+		const { seen, release } = fixture();
+		expect(texts(seen)).toEqual([["busy"]]);
+		release();
+	});
+
+	it("does not extend the active turn; joins only pending messages", async () => {
+		const { queue, seen, release } = fixture();
+		queue.enqueue(message("one"));
+		queue.enqueue(message("two"));
+		expect(texts(seen)).toEqual([["busy"]]);
+		release();
+		await vi.waitFor(() => expect(texts(seen)).toEqual([["busy"], ["one", "two"]]));
+	});
+
+	it("does not merge across a different speaker", async () => {
+		const { queue, seen, release } = fixture();
+		queue.enqueue(message("a1"));
+		queue.enqueue(message("a2"));
+		queue.enqueue(message("b1", { sender: "bob" }));
+		queue.enqueue(message("a3"));
+		release();
+		await vi.waitFor(() => expect(texts(seen)).toEqual([["busy"], ["a1", "a2"], ["b1"], ["a3"]]));
+	});
+
+	it("runs other chats concurrently and releases idle chat state", async () => {
+		const { queue, seen, release } = fixture();
+		queue.enqueue(message("other", { chatGuid: "group-b" }));
+		expect(texts(seen)).toEqual([["busy"], ["other"]]);
+		await Promise.resolve();
+		queue.enqueue(message("other-again", { chatGuid: "group-b" }));
+		expect(texts(seen)).toEqual([["busy"], ["other"], ["other-again"]]);
+		release();
+	});
+
+	it.each([
+		["command", message("  /new")],
+		["unknown slash command", message("/future-command")],
+		["quote", message("quoted", { replyToText: "earlier text" })],
+		["attachment", message(null, { attachments: [{ path: "/fixture/image.png", mimeType: "image/png" }] })],
+		["loaded image", message("image", { images: [{ type: "image", data: "AA==", mimeType: "image/png" }] })],
+		["blank text", message(" ")],
+		["unknown sender", message("unknown", { sender: "" })],
+		["renamed group", message("renamed", { groupName: "Renamed" })],
+		["different service", message("sms", { messageType: "sms" })],
+	])("keeps %s as a standalone boundary", async (_name, middle) => {
+		const { queue, seen, release } = fixture();
+		queue.enqueue(message("before"));
+		queue.enqueue(middle);
+		queue.enqueue(message("after"));
+		release();
+		await vi.waitFor(() => expect(seen).toHaveLength(4));
+		expect(seen[1]).toEqual([message("before")]);
+		expect(seen[2]).toEqual([middle]);
+		expect(seen[3]).toEqual([message("after")]);
+	});
+
+	it("caps batches at eight messages without losing input", async () => {
+		const { queue, seen, release } = fixture();
+		for (let i = 0; i < 10; i++) queue.enqueue(message(String(i)));
+		release();
+		await vi.waitFor(() => expect(seen).toHaveLength(3));
+		expect(seen.map((batch) => batch.length)).toEqual([1, 8, 2]);
+		expect(texts(seen).flat()).toEqual(["busy", ...Array.from({ length: 10 }, (_, i) => String(i))]);
+	});
+
+	it("caps merged text size but never truncates an individual long message", async () => {
+		const { queue, seen, release } = fixture();
+		queue.enqueue(message("a".repeat(3999)));
+		queue.enqueue(message("b".repeat(3999)));
+		queue.enqueue(message("c"));
+		queue.enqueue(message("d".repeat(9000)));
+		release();
+		await vi.waitFor(() => expect(seen).toHaveLength(4));
+		expect(seen.map((batch) => batch.length)).toEqual([1, 2, 1, 1]);
+		expect(joinTextBatch(seen[1]).text).toHaveLength(8000);
+		expect(seen[3][0].text).toHaveLength(9000);
+	});
+
+	it("preserves the boundary of a bypassed stop command", async () => {
+		const { queue, seen, release } = fixture();
+		queue.enqueue(message("before-stop"));
+		queue.boundary("group-a");
+		queue.enqueue(message("after-stop"));
+		release();
+		await vi.waitFor(() => expect(texts(seen)).toEqual([["busy"], ["before-stop"], ["after-stop"]]));
+	});
+
+	it("continues after a failed batch without automatically replaying it", async () => {
+		const log = vi.spyOn(console, "error").mockImplementation(() => {});
+		const process = vi.fn().mockRejectedValueOnce(new Error("failure")).mockResolvedValue(undefined);
+		const queue = createMessageBatchQueue(process);
+		queue.enqueue(message("fails"));
+		queue.enqueue(message("next"));
+		await vi.waitFor(() => expect(process).toHaveBeenCalledTimes(2));
+		expect(log).toHaveBeenCalledOnce();
+		log.mockRestore();
+	});
+
+	it("preserves exact text and metadata, without mutating the originals", () => {
+		const a = message(" first\nline ");
+		const b = message("second");
+		expect(joinTextBatch([a, b])).toEqual({ ...a, text: " first\nline \n\nsecond" });
+		expect(a.text).toBe(" first\nline ");
+		expect(b.text).toBe("second");
+		expect(joinTextBatch([a])).toBe(a);
+		expect(() => joinTextBatch([a, message("b", { sender: "bob" })])).toThrow("boundary");
+		expect(() => joinTextBatch([a, message("/new")])).toThrow("boundary");
+		expect(() => joinTextBatch([])).toThrow("empty");
+	});
+});

--- a/src/imessage.ts
+++ b/src/imessage.ts
@@ -4,16 +4,16 @@
  *
  *   watcher → queue → pipeline.process()
  *
- * Message ordering: every pulled message is immediately dispatched to the
- * pipeline (fire-and-forget). Different chats run concurrently. Same-chat
- * messages are serialized via per-chat promise chains so the agent never
- * receives concurrent prompts for the same session.
+ * Different chats run concurrently. Idle chats start immediately. While a
+ * chat is busy, consecutive same-sender plain-text messages can be processed
+ * as one turn. Commands, attachments, quotes, and sender changes split batches.
  */
 
 import type { AgentManager } from "./agent.js";
 import type { DigestLogger } from "./logger.js";
+import { createMessageBatchQueue } from "./message-batch.js";
 import { createMessagePipeline } from "./pipeline.js";
-import { type AsyncQueue, QueueClosedError, createKeyedQueue } from "./queue.js";
+import { type AsyncQueue, QueueClosedError } from "./queue.js";
 import type { SelfEchoFilter } from "./self-echo.js";
 import type { MessageSender } from "./send.js";
 import type { Settings } from "./settings.js";
@@ -76,7 +76,12 @@ export function createIMessageBot(config: IMessageBotConfig) {
 
 	return {
 		start() {
-			const enqueue = createKeyedQueue();
+			const batches = createMessageBatchQueue(async (messages) => {
+				if (messages.length > 1) {
+					console.log(`[batch] ${messages[0].chatGuid}: merged ${messages.length} pending text messages`);
+				}
+				await pipeline.processBatch(messages);
+			});
 
 			async function loop(): Promise<void> {
 				while (true) {
@@ -84,6 +89,7 @@ export function createIMessageBot(config: IMessageBotConfig) {
 
 					// /stop bypasses the per-chat queue so it can abort a running prompt
 					if (msg.text?.trim() === "/stop") {
+						batches.boundary(msg.chatGuid);
 						await agent.stop(msg.chatGuid);
 						const replyText = "✓ Stopped";
 						console.log(`[sid] /stop command: ${msg.chatGuid} → ${replyText}`);
@@ -91,13 +97,7 @@ export function createIMessageBot(config: IMessageBotConfig) {
 						continue;
 					}
 
-					enqueue(msg.chatGuid, async () => {
-						try {
-							await pipeline.process(msg);
-						} catch (error: unknown) {
-							console.error(`[sid] failed to process message from ${msg.sender}:`, error);
-						}
-					});
+					batches.enqueue(msg);
 				}
 			}
 

--- a/src/message-batch.ts
+++ b/src/message-batch.ts
@@ -1,0 +1,89 @@
+import type { IncomingMessage } from "./types.js";
+
+// Bounds apply to merging, not to an individual message. Never truncate input.
+export const MAX_BATCH_MESSAGES = 8;
+export const MAX_BATCH_TEXT_LENGTH = 8_000;
+
+export function isBatchableText(message: IncomingMessage): boolean {
+	return Boolean(
+		message.sender.trim() &&
+			message.text?.trim() &&
+			!message.text.trim().startsWith("/") &&
+			message.replyToText === null &&
+			message.attachments.length === 0 &&
+			message.images.length === 0
+	);
+}
+
+export function canAppendToBatch(batch: readonly IncomingMessage[], next: IncomingMessage): boolean {
+	const first = batch[0];
+	return Boolean(
+		first &&
+			batch.length < MAX_BATCH_MESSAGES &&
+			batch.every(isBatchableText) &&
+			isBatchableText(next) &&
+			first.chatGuid === next.chatGuid &&
+			first.sender === next.sender &&
+			first.messageType === next.messageType &&
+			first.groupName === next.groupName &&
+			batch.reduce((size, message) => size + (message.text?.length ?? 0) + 2, 0) + (next.text?.length ?? 0) <=
+				MAX_BATCH_TEXT_LENGTH
+	);
+}
+
+export function joinTextBatch(batch: readonly IncomingMessage[]): IncomingMessage {
+	const first = batch[0];
+	if (!first) throw new Error("Cannot join an empty message batch");
+	for (let i = 1; i < batch.length; i++) {
+		if (!canAppendToBatch(batch.slice(0, i), batch[i])) {
+			throw new Error("Invalid message batch boundary");
+		}
+	}
+	if (batch.length === 1) return first;
+	return { ...first, text: batch.map((message) => message.text).join("\n\n") };
+}
+
+/** No debounce: start idle chats immediately, coalesce only pending messages. */
+export function createMessageBatchQueue(process: (batch: IncomingMessage[]) => Promise<void>) {
+	type Entry = { message: IncomingMessage; boundary: number };
+	type State = { pending: Entry[]; boundary: number };
+	const chats = new Map<string, State>();
+
+	async function drain(chatGuid: string, state: State): Promise<void> {
+		while (state.pending.length > 0) {
+			const first = state.pending.shift();
+			if (!first) break;
+			const batch = [first.message];
+			while (state.pending.length > 0) {
+				const next = state.pending[0];
+				if (next.boundary !== first.boundary || !canAppendToBatch(batch, next.message)) break;
+				batch.push(next.message);
+				state.pending.shift();
+			}
+			try {
+				await process(batch);
+			} catch (error: unknown) {
+				console.error(`[batch] failed to process ${batch.length} message(s) for ${chatGuid}:`, error);
+			}
+		}
+		chats.delete(chatGuid);
+	}
+
+	return {
+		enqueue(message: IncomingMessage): void {
+			const existing = chats.get(message.chatGuid);
+			if (existing) {
+				existing.pending.push({ message, boundary: existing.boundary });
+				return;
+			}
+			const state: State = { pending: [{ message, boundary: 0 }], boundary: 0 };
+			chats.set(message.chatGuid, state);
+			void drain(message.chatGuid, state);
+		},
+		/** Preserve the ordering boundary of a command that bypasses the queue. */
+		boundary(chatGuid: string): void {
+			const state = chats.get(chatGuid);
+			if (state) state.boundary++;
+		},
+	};
+}

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -12,6 +12,7 @@
  *            Receives ChatContext (not IncomingMessage) — only chat-level identity.
  */
 
+import { joinTextBatch } from "./message-batch.js";
 import type { ChatContext, IncomingMessage, OutgoingMessage } from "./types.js";
 import { createOutgoingMessage, toChatContext } from "./types.js";
 
@@ -37,6 +38,7 @@ export interface MessagePipeline {
 	start(task: StartTask): void;
 	end(task: EndTask): void;
 	process(incoming: IncomingMessage): Promise<OutgoingMessage>;
+	processBatch(incoming: IncomingMessage[]): Promise<void>;
 }
 
 export function createMessagePipeline(): MessagePipeline {
@@ -52,15 +54,18 @@ export function createMessagePipeline(): MessagePipeline {
 		}
 	}
 
-	async function process(incoming: IncomingMessage): Promise<OutgoingMessage> {
+	async function prepare(incoming: IncomingMessage): Promise<OutgoingMessage> {
 		const chat = toChatContext(incoming);
 		let outgoing = createOutgoingMessage();
-
 		for (const task of beforeTasks) {
 			outgoing = await task(chat, incoming, outgoing);
-			if (!outgoing.shouldContinue) return outgoing;
+			if (!outgoing.shouldContinue) break;
 		}
+		return outgoing;
+	}
 
+	async function run(incoming: IncomingMessage, outgoing: OutgoingMessage): Promise<OutgoingMessage> {
+		const chat = toChatContext(incoming);
 		// emit() is sync — queues end tasks onto endChain for serialized execution
 		let endChain = Promise.resolve();
 		const emit: EmitFn = (out) => {
@@ -79,10 +84,41 @@ export function createMessagePipeline(): MessagePipeline {
 		return outgoing;
 	}
 
+	async function process(incoming: IncomingMessage): Promise<OutgoingMessage> {
+		const outgoing = await prepare(incoming);
+		return outgoing.shouldContinue ? run(incoming, outgoing) : outgoing;
+	}
+
+	async function processBatch(messages: IncomingMessage[]): Promise<void> {
+		if (messages.length === 0) return;
+		if (messages.length === 1) {
+			await process(messages[0]);
+			return;
+		}
+		// Validate before any task can mutate an input or produce a side effect.
+		joinTextBatch(messages);
+		const prepared: IncomingMessage[] = [];
+		let firstOutgoing: OutgoingMessage | undefined;
+		for (const message of messages) {
+			try {
+				// Log/store/filter each ORIGINAL message, never the synthetic joined text.
+				const outgoing = await prepare(message);
+				if (outgoing.shouldContinue) {
+					prepared.push(message);
+					firstOutgoing ??= outgoing;
+				}
+			} catch (error: unknown) {
+				console.error(`[pipeline] before task error for ${message.chatGuid}:`, error);
+			}
+		}
+		if (firstOutgoing) await run(joinTextBatch(prepared), firstOutgoing);
+	}
+
 	return {
 		before: (task) => beforeTasks.push(task),
 		start: (task) => startTasks.push(task),
 		end: (task) => endTasks.push(task),
 		process,
+		processBatch,
 	};
 }


### PR DESCRIPTION
Minimal batching v1, following #23. Idle chats start immediately. Only consecutive, same-sender plain-text messages already waiting behind an active turn are merged.

<img width="1000" alt="A1 and A2 share a batch. B1 and A3 remain separate, preserving sender boundaries and order." src="https://raw.githubusercontent.com/daya0576/pi-imessage/8aab11190b3127dd283f2724cd25992f3512ebfb/issue-23/02-sender-boundary.png">

Slash commands, quoted replies, attachments, images, and sender changes split batches. /stop still bypasses the queue and creates a merge boundary. Bounds: eight messages / 8,000 UTF-16 code units; no truncation of individual messages.

Each original message is independently logged, stored, and filtered before joining its text for one agent call. Other chats remain concurrent. Streaming/tool replies are unchanged.

No debounce, steer, silence policy, new dependencies, or settings. Pending work is still in memory; this does not add crash-safe acknowledgement or exactly-once delivery. No production deployment.

Validation: 25 new tests, 109 total passing; typecheck, Biome check, and build passed. Integration tests exercise the real bot/pipeline with mocked agent and sender—no live model calls or Messages sends.
