### PR TITLE
fix(ops): 保护当前版本的安全清理

### DIFF
--- a/ops/deploy-blue-green.sh
+++ b/ops/deploy-blue-green.sh
@@ -232,10 +232,7 @@ DEPLOY_SUCCEEDED=true
 send_progress "pi-imessage 已完成蓝绿切换，切换后真实 LLM 健康检查通过。"
 log "Deployment succeeded"
 
-# Keep current, previous, and the newest spare release; remove older immutable builds.
-CURRENT_REAL="$(realpath "${CURRENT_LINK}")"
-PREVIOUS_REAL="$(realpath "${PREVIOUS_LINK}" 2>/dev/null || true)"
-while IFS= read -r stale; do
-  [[ "${stale}" == "${CURRENT_REAL}" || "${stale}" == "${PREVIOUS_REAL}" ]] && continue
-  rm -rf "${stale}"
-done < <(find "${RELEASE_ROOT}" -maxdepth 1 -type d -name 'pi-imessage-*' -print | sort -r | tail -n +4)
+# Resolve every candidate and reference through the same filesystem namespace.
+# Cleanup is fail-closed and best-effort, never a reason to damage a healthy release.
+/usr/bin/python3 "${SCRIPT_DIR}/prune-releases.py" "${RELEASE_ROOT}" "${CURRENT_LINK}" "${PREVIOUS_LINK}" --apply \
+  || log "Release cleanup skipped; retained builds for operator review"

--- a/ops/prune-releases.py
+++ b/ops/prune-releases.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""Prune only old direct release directories; default is a read-only plan."""
+import argparse
+import pathlib
+import shutil
+
+
+def plan(root, current, previous):
+    root = pathlib.Path(root).resolve(strict=True)
+    # Broken or unexpected references fail closed: do not delete any release.
+    protected = {pathlib.Path(current).resolve(strict=True), pathlib.Path(previous).resolve(strict=True)}
+    if any(p.parent != root or not p.is_dir() for p in protected):
+        raise ValueError('release reference is outside the direct release root')
+    candidates = [p for p in root.iterdir() if p.name.startswith('pi-imessage-') and not p.is_symlink() and p.is_dir()]
+    spares = sorted((p for p in candidates if p not in protected), key=lambda p: (p.stat().st_mtime_ns, p.name), reverse=True)
+    return spares[1:]
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('root')
+    parser.add_argument('current')
+    parser.add_argument('previous')
+    parser.add_argument('--apply', action='store_true')
+    args = parser.parse_args()
+    try:
+        stale = plan(args.root, args.current, args.previous)
+        for candidate in stale:
+            # A concurrently changed reference can only make cleanup more conservative.
+            if candidate not in plan(args.root, args.current, args.previous):
+                continue
+            print(('remove ' if args.apply else 'would remove ') + str(candidate))
+            if args.apply:
+                shutil.rmtree(candidate)
+    except (OSError, ValueError) as error:
+        print('Release cleanup skipped: ' + type(error).__name__)
+        return 1
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/ops/test_prune_releases.py
+++ b/ops/test_prune_releases.py
@@ -1,0 +1,45 @@
+import importlib.util
+import os
+import pathlib
+import tempfile
+import unittest
+
+spec = importlib.util.spec_from_file_location('prune', pathlib.Path(__file__).with_name('prune-releases.py'))
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+
+
+class PruningTests(unittest.TestCase):
+    def test_alias_paths_protect_current_previous_and_newest_spare(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = pathlib.Path(directory) / 'real'
+            root.mkdir()
+            alias = pathlib.Path(directory) / 'alias'
+            alias.symlink_to(root, target_is_directory=True)
+            names = ['pi-imessage-000-current', 'pi-imessage-001-previous', 'pi-imessage-z-old', 'pi-imessage-a-new']
+            for index, name in enumerate(names):
+                (root / name).mkdir()
+                os.utime(root / name, (index + 1, index + 1))
+            (root / 'current').symlink_to(alias / names[0])
+            (root / 'previous').symlink_to(alias / names[1])
+            self.assertEqual(module.plan(alias, alias/'current', alias/'previous'), [(root/names[2]).resolve()])
+
+    def test_broken_reference_refuses_cleanup(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = pathlib.Path(directory)
+            (root/'pi-imessage-old').mkdir()
+            (root/'current').symlink_to(root/'missing')
+            with self.assertRaises(FileNotFoundError):
+                module.plan(root, root/'current', root/'current')
+
+    def test_external_reference_refuses_cleanup(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = pathlib.Path(directory)/'releases'
+            root.mkdir()
+            (root/'current').symlink_to(pathlib.Path(directory))
+            with self.assertRaises(ValueError):
+                module.plan(root, root/'current', root/'current')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Source-only import of the pending release-pruning fix, based on origin/main rather than the diverged live branch.

Changes: canonicalize current/previous/candidate paths; keep a spare; refuse broken or external references; add three synthetic temporary-directory regressions. Exactly three ops source/test files, no release archives or runtime metadata.

Validation: full npm run check (TypeScript/Biome, 47 files); bash -n; three isolated Python unit tests; full diff/file-list privacy review and before/after source hashes. No deployment script, live cleanup, service action or network-backed test executed.

Draft because this changes destructive cleanup behavior. Synthetic tests are not live deployment validation; normal deployment locking remains important. No auto-merge or deployment requested.
